### PR TITLE
feat: disable query logging in production

### DIFF
--- a/src/components/landing/Testimonials.tsx
+++ b/src/components/landing/Testimonials.tsx
@@ -47,7 +47,7 @@ export function Testimonials() {
                 <div className="p-1">
                   <Card className="bg-lp-primary-2 border-lp-sec-1/20 shadow-lg">
                     <CardContent className="flex flex-col items-start p-6">
-                      <p className="text-base text-lp-sec-3 italic">"{testimonial.quote}"</p>
+                      <p className="text-base text-lp-sec-3 italic">&ldquo;{testimonial.quote}&rdquo;</p>
                       <div className="mt-4">
                         <p className="font-bold text-lp-primary-1">{testimonial.name}</p>
                         <p className="text-sm text-lp-sec-3">{testimonial.company}</p>

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -2,14 +2,13 @@ import { PrismaClient } from '@prisma/client';
 
 declare global {
   // allow global `var` declarations
-  // eslint-disable-next-line no-var
   var prisma: PrismaClient | undefined;
 }
 
 export const prisma =
   global.prisma ||
   new PrismaClient({
-    log: ['query'],
+    log: process.env.NODE_ENV === 'development' ? ['query'] : [],
   });
 
 if (process.env.NODE_ENV !== 'production') global.prisma = prisma;


### PR DESCRIPTION
## Summary
- log Prisma queries only in development
- escape testimonial quotes to satisfy lint rules

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: warnings and manual interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68a3559aa788832f954d76b31ce3e19f