### PR TITLE
chore: generate prisma client on install

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "postinstall": "prisma generate"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.1",


### PR DESCRIPTION
## Summary
- run `prisma generate` after dependencies install to ensure client is available

## Testing
- `npm install`
- `npm run build` *(fails: Type error in PreApprovalForm.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68a37ff8a138832f92baaecb3fc2e939