### PR TITLE
feat: send contact emails via Resend

### DIFF
--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -1,28 +1,25 @@
 import { NextResponse } from 'next/server';
 import { ContactValidator } from '@/lib/validators/contact';
 import { z } from 'zod';
-// import { Resend } from 'resend';
+import { Resend } from 'resend';
 
-// const resend = new Resend(process.env.RESEND_API_KEY);
+const resend = new Resend(process.env.RESEND_API_KEY);
 
 export async function POST(req: Request) {
   try {
     const body = await req.json();
     const { nombre, email, telefono, mensaje } = ContactValidator.parse(body);
 
-    // TODO: Implement Resend email sending
-    /*
     await resend.emails.send({
-      from: 'onboarding@resend.dev', // Change to your domain
-      to: 'admin@lepret.co', // Your admin email
+      from: 'onboarding@resend.dev',
+      to: [email, 'admin@lepret.co'],
       subject: `Nuevo Mensaje de Contacto de ${nombre}`,
       html: `<p><strong>Nombre:</strong> ${nombre}</p>
              <p><strong>Email:</strong> ${email}</p>
              <p><strong>Teléfono:</strong> ${telefono || 'No proporcionado'}</p>
              <p><strong>Mensaje:</strong></p>
-             <p>${mensaje}</p>`,
+             <p>${mensaje}</p>`
     });
-    */
 
     return NextResponse.json({ message: 'Mensaje enviado con éxito. Nos pondremos en contacto contigo pronto.' });
 
@@ -33,7 +30,7 @@ export async function POST(req: Request) {
 
     console.error(error);
     return new NextResponse(
-      JSON.stringify({ message: 'Ocurrió un error en el servidor.' }),
+      JSON.stringify({ message: 'Ocurrió un error al enviar el correo.' }),
       { status: 500 }
     );
   }


### PR DESCRIPTION
## Summary
- integrate Resend email service for contact form submissions
- send contact messages to both the user and admin addresses
- improve error handling for failed email sends

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a37ff91e1c832fbb10b14413a544cc