### PR TITLE
feat: add icons to benefits section

### DIFF
--- a/src/components/landing/Benefits.tsx
+++ b/src/components/landing/Benefits.tsx
@@ -1,33 +1,53 @@
-const benefits = [
+import {
+  MousePointerClick,
+  Timer,
+  Globe2,
+  ShieldCheck,
+  FileText,
+  LifeBuoy,
+  type LucideIcon,
+} from 'lucide-react';
+
+const benefits: {
+  name: string;
+  description: string;
+  icon: LucideIcon;
+}[] = [
   {
     name: 'Preaprobación Online',
-    description: 'Obtén una oferta preliminar en minutos, sin papeleo y 100% en línea.',
-    icon: '✔️',
+    description:
+      'Obtén una oferta preliminar en minutos, sin papeleo y 100% en línea.',
+    icon: MousePointerClick,
   },
   {
     name: 'Fondos en 24-48h',
-    description: 'Accede a tu liquidez rápidamente una vez verificada la operación.',
-    icon: '✔️',
+    description:
+      'Accede a tu liquidez rápidamente una vez verificada la operación.',
+    icon: Timer,
   },
   {
     name: 'Integrado a la DIAN',
-    description: 'Conectamos directamente con RADIAN para un proceso ágil y seguro.',
-    icon: '✔️',
+    description:
+      'Conectamos directamente con RADIAN para un proceso ágil y seguro.',
+    icon: Globe2,
   },
   {
     name: 'No Afecta tu Crédito',
-    description: 'El factoring es una venta de activo, no una deuda. No consume tus cupos de crédito.',
-    icon: '✔️',
+    description:
+      'El factoring es una venta de activo, no una deuda. No consume tus cupos de crédito.',
+    icon: ShieldCheck,
   },
   {
     name: 'Transparencia Total',
-    description: 'Conoce todos los costos desde el inicio. Sin letra pequeña ni sorpresas.',
-    icon: '✔️',
+    description:
+      'Conoce todos los costos desde el inicio. Sin letra pequeña ni sorpresas.',
+    icon: FileText,
   },
   {
     name: 'Soporte Humano',
-    description: 'Nuestro equipo de expertos está disponible para ayudarte cuando lo necesites.',
-    icon: '✔️',
+    description:
+      'Nuestro equipo de expertos está disponible para ayudarte cuando lo necesites.',
+    icon: LifeBuoy,
   },
 ];
 
@@ -45,9 +65,9 @@ export function Benefits() {
         </div>
         <div className="mt-16 grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-3">
           {benefits.map((benefit) => (
-            <div key={benefit.name} className="flex items-start space-x-4">
-              <div>
-                <span className="text-2xl">{benefit.icon}</span>
+            <div key={benefit.name} className="flex items-start gap-4">
+              <div className="flex h-12 w-12 flex-none items-center justify-center rounded-lg bg-lp-primary-2">
+                <benefit.icon className="size-6 text-lp-primary-1" aria-hidden="true" />
               </div>
               <div>
                 <h3 className="font-colette text-xl font-semibold text-lp-primary-1">{benefit.name}</h3>


### PR DESCRIPTION
## Summary
- replace text-based benefit markers with lucide-react icons
- apply Tailwind styling for uniform icon appearance
- ensure icons are hidden from screen readers for accessibility

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a49b39bb1c832f950733342185e03c