### PR TITLE
feat(forms): add reusable form error component

### DIFF
--- a/src/components/forms/ContactForm.tsx
+++ b/src/components/forms/ContactForm.tsx
@@ -9,6 +9,7 @@ import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Toaster, toast } from "sonner";
 import { useState } from "react";
+import { FormError } from "./FormError";
 
 export function ContactForm() {
   const [isLoading, setIsLoading] = useState<boolean>(false);
@@ -57,13 +58,19 @@ export function ContactForm() {
         <div>
           <Label htmlFor="nombre">Nombre Completo</Label>
           <Input id="nombre" {...form.register("nombre")} />
-          {form.formState.errors.nombre && <p className="text-red-500 text-sm mt-1">{form.formState.errors.nombre.message}</p>}
+          <FormError
+            message={form.formState.errors.nombre?.message}
+            className="mt-1"
+          />
         </div>
         
         <div>
           <Label htmlFor="email">Email de Contacto</Label>
           <Input id="email" type="email" {...form.register("email")} />
-          {form.formState.errors.email && <p className="text-red-500 text-sm mt-1">{form.formState.errors.email.message}</p>}
+          <FormError
+            message={form.formState.errors.email?.message}
+            className="mt-1"
+          />
         </div>
 
         <div>
@@ -74,7 +81,10 @@ export function ContactForm() {
         <div>
           <Label htmlFor="mensaje">Mensaje</Label>
           <Textarea id="mensaje" rows={5} {...form.register("mensaje")} />
-          {form.formState.errors.mensaje && <p className="text-red-500 text-sm mt-1">{form.formState.errors.mensaje.message}</p>}
+          <FormError
+            message={form.formState.errors.mensaje?.message}
+            className="mt-1"
+          />
         </div>
 
         <Button type="submit" disabled={isLoading} className="w-full" size="lg">

--- a/src/components/forms/FormError.tsx
+++ b/src/components/forms/FormError.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+
+interface FormErrorProps {
+  message?: string;
+  className?: string;
+}
+
+export function FormError({ message, className }: FormErrorProps) {
+  if (!message) return null;
+
+  return (
+    <p className={cn("text-red-500 text-sm", className)} aria-live="polite">
+      {message}
+    </p>
+  );
+}

--- a/src/components/forms/PreApprovalForm.tsx
+++ b/src/components/forms/PreApprovalForm.tsx
@@ -11,6 +11,7 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Toaster, toast } from "sonner";
 import { useState } from "react";
 import { format } from 'd3-format';
+import { FormError } from "./FormError";
 
 export function PreApprovalForm() {
   const [isLoading, setIsLoading] = useState<boolean>(false);
@@ -88,7 +89,10 @@ export function PreApprovalForm() {
           <div>
             <Label htmlFor="nit">NIT</Label>
             <Input id="nit" {...form.register("nit")} />
-            {form.formState.errors.nit && <p className="text-red-500 text-sm mt-1">{form.formState.errors.nit.message}</p>}
+            <FormError
+              message={form.formState.errors.nit?.message}
+              className="mt-1"
+            />
           </div>
           <div>
             <Label htmlFor="razonSocial">Razón Social</Label>
@@ -99,26 +103,38 @@ export function PreApprovalForm() {
         <div>
           <Label htmlFor="ventasAnuales">Ventas Anuales (COP)</Label>
           <Input id="ventasAnuales" type="number" {...form.register("ventasAnuales")} />
-          {form.formState.errors.ventasAnuales && <p className="text-red-500 text-sm mt-1">{form.formState.errors.ventasAnuales.message}</p>}
+          <FormError
+            message={form.formState.errors.ventasAnuales?.message}
+            className="mt-1"
+          />
         </div>
 
         <div className="grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-2">
             <div>
                 <Label htmlFor="facturasMes"># Facturas/Mes</Label>
                 <Input id="facturasMes" type="number" {...form.register("facturasMes")} />
-                {form.formState.errors.facturasMes && <p className="text-red-500 text-sm mt-1">{form.formState.errors.facturasMes.message}</p>}
+                <FormError
+                  message={form.formState.errors.facturasMes?.message}
+                  className="mt-1"
+                />
             </div>
             <div>
                 <Label htmlFor="ticketPromedio">Ticket Promedio Factura (COP)</Label>
                 <Input id="ticketPromedio" type="number" {...form.register("ticketPromedio")} />
-                {form.formState.errors.ticketPromedio && <p className="text-red-500 text-sm mt-1">{form.formState.errors.ticketPromedio.message}</p>}
+                <FormError
+                  message={form.formState.errors.ticketPromedio?.message}
+                  className="mt-1"
+                />
             </div>
         </div>
 
         <div>
           <Label htmlFor="email">Email de Contacto</Label>
           <Input id="email" type="email" {...form.register("email")} />
-          {form.formState.errors.email && <p className="text-red-500 text-sm mt-1">{form.formState.errors.email.message}</p>}
+          <FormError
+            message={form.formState.errors.email?.message}
+            className="mt-1"
+          />
         </div>
 
         <div>
@@ -132,7 +148,7 @@ export function PreApprovalForm() {
             Acepto la <a href="/legal/privacidad" target="_blank" className="underline">política de tratamiento de datos</a>.
           </Label>
         </div>
-        {form.formState.errors.consent && <p className="text-red-500 text-sm">{form.formState.errors.consent.message}</p>}
+        <FormError message={form.formState.errors.consent?.message} />
 
         {error && <Alert variant="destructive"><AlertDescription>{error}</AlertDescription></Alert>}
 


### PR DESCRIPTION
## Summary
- add `FormError` component with `aria-live="polite"`
- use `FormError` in `ContactForm` and `PreApprovalForm`

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a49b4ad4d0832f92a896620d910eb6