### PR TITLE
style: improve spacing in pricing example inputs

### DIFF
--- a/src/components/PricingExample.tsx
+++ b/src/components/PricingExample.tsx
@@ -35,7 +35,7 @@ export function PricingExample({ monto, plazo }: PricingExampleProps) {
   return (
     <div className="mt-8 rounded-lg border border-lp-sec-4/50 bg-lp-primary-1/5 p-6">
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-        <div>
+        <div className="space-y-2">
           <Label htmlFor="monto">Monto de la factura (COP)</Label>
           <Input
             id="monto"
@@ -45,7 +45,7 @@ export function PricingExample({ monto, plazo }: PricingExampleProps) {
             onChange={handleAmountChange}
           />
         </div>
-        <div>
+        <div className="space-y-2">
           <Label htmlFor="plazo">Plazo (días)</Label>
           <Input
             id="plazo"


### PR DESCRIPTION
## Summary
- add vertical spacing between labels and inputs in pricing example

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4bf9cab00832fa3e357638f51d647