### PR TITLE
refactor: re-export Button as Btn

### DIFF
--- a/src/components/landing/Hero.tsx
+++ b/src/components/landing/Hero.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link';
 import Image from 'next/image';
-import { Button } from '@/components/ui/button';
+import { Btn } from '@/components/ui/btn';
 
 export function Hero() {
   return (
@@ -13,12 +13,12 @@ export function Hero() {
           Proceso 100% en línea. Preaprobación en minutos. Desembolso ágil. Sin afectar tu capacidad de crédito.
         </p>
         <div className="mt-10 flex items-center justify-center gap-x-6">
-          <Button asChild size="lg">
+          <Btn asChild size="lg">
             <Link href="/preaprobacion">Conocer mi cupo</Link>
-          </Button>
-          <Button asChild variant="link" className="text-lp-primary-1">
+          </Btn>
+          <Btn asChild variant="link" className="text-lp-primary-1">
             <Link href="/contacto">Hablar con un asesor <span aria-hidden="true">→</span></Link>
-          </Button>
+          </Btn>
         </div>
         <div className="mt-16 flow-root">
             <div className="rounded-2xl bg-lp-sec-4 p-2 ring-1 ring-inset ring-lp-sec-1/10 lg:p-4">

--- a/src/components/ui/btn.tsx
+++ b/src/components/ui/btn.tsx
@@ -1,16 +1,1 @@
-import { cn } from "@/lib/utils"
-
-type Props = React.ButtonHTMLAttributes<HTMLButtonElement> & {
-  variant?: "primary" | "ghost" | "secondary"
-  asChild?: boolean
-}
-
-export function Btn({ className, variant="primary", ...props }: Props) {
-  const base = "inline-flex items-center justify-center h-12 px-5 rounded-2xl text-sm font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-lp.sec2"
-  const styles = {
-    primary:  "bg-lp-primary1 text-lp-primary2 hover:opacity-90 shadow-soft",
-    ghost:    "border border-lp-primary1/25 text-lp-primary1 hover:bg-lp-primary1/5",
-    secondary:"bg-lp-sec3 text-white hover:opacity-95 shadow-soft"
-  } as const
-  return <button className={cn(base, styles[variant], className)} {...props} />
-}
+export { Button as Btn } from "@/components/ui/button";


### PR DESCRIPTION
## Summary
- re-export Button as Btn in shared ui
- switch Hero component to use Btn wrapper

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5899dcd48832f93fb26031970233d