### PR TITLE
chore: use hyphenated lp color keys

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,19 +10,19 @@ export default function Home() {
   return (
     <>
       <Hero />
-      <section className="py-20 bg-lp-sec4">
+      <section className="py-20 bg-lp-sec-4">
         <HowItWorks />
       </section>
       <section className="py-20">
         <Benefits />
       </section>
-      <section className="py-20 bg-lp-sec4">
+      <section className="py-20 bg-lp-sec-4">
         <TrustMetrics />
       </section>
       <section className="py-20">
         <Allies />
       </section>
-      <section className="py-20 bg-lp-sec4">
+      <section className="py-20 bg-lp-sec-4">
         <Testimonials />
       </section>
       <section className="py-20">

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -4,7 +4,7 @@ import { Logo } from './Logo';
 export function Footer() {
   const currentYear = new Date().getFullYear();
   return (
-    <footer className="bg-lp-primary1 text-lp-primary2 border-t border-lp-primary2/20">
+    <footer className="bg-lp-primary-1 text-lp-primary-2 border-t border-lp-primary-2/20">
       <div className="container mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-12">
         <div className="grid grid-cols-1 md:grid-cols-4 gap-8">
           <div className="space-y-4">

--- a/src/components/landing/Hero.tsx
+++ b/src/components/landing/Hero.tsx
@@ -6,23 +6,23 @@ import { Section } from '@/components/layout/Section';
 
 export function Hero() {
   return (
-    <Section className="py-20 sm:py-32 bg-lp-primary2 text-center">
-      <h1 className="font-colette text-4xl font-bold tracking-tight text-lp-primary1 sm:text-5xl lg:text-6xl">
+    <Section className="py-20 sm:py-32 bg-lp-primary-2 text-center">
+      <h1 className="font-colette text-4xl font-bold tracking-tight text-lp-primary-1 sm:text-5xl lg:text-6xl">
         Liquidez inmediata para tus facturas electrónicas
       </h1>
-      <p className="mt-6 text-lg leading-8 text-lp-sec3 max-w-2xl mx-auto">
+      <p className="mt-6 text-lg leading-8 text-lp-sec-3 max-w-2xl mx-auto">
         Proceso 100% en línea. Preaprobación en minutos. Desembolso ágil. Sin afectar tu capacidad de crédito.
       </p>
       <div className="mt-10 flex items-center justify-center gap-x-6">
         <Button asChild size="lg">
           <Link href="/preaprobacion">Conocer mi cupo</Link>
         </Button>
-        <Button asChild variant="link" className="text-lp-primary1">
+        <Button asChild variant="link" className="text-lp-primary-1">
           <Link href="/contacto">Hablar con un asesor <span aria-hidden="true">→</span></Link>
         </Button>
       </div>
       <div className="mt-16 flow-root">
-        <div className="rounded-2xl bg-lp-sec4 p-2 ring-1 ring-inset ring-lp-sec1/10 lg:p-4">
+        <div className="rounded-2xl bg-lp-sec-4 p-2 ring-1 ring-inset ring-lp-sec-1/10 lg:p-4">
           <div className="bg-white rounded-xl shadow-2xl ring-1 ring-gray-900/10 h-96 overflow-hidden">
             <Image
               src="/liquidez.png"

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -10,12 +10,12 @@ const config: Config = {
     extend: {
       colors: {
         lp: {
-          primary1: "#18240f", // verde oscuro
-          primary2: "#fffffa", // crema (casi blanco)
-          sec1: "#afb6a6", // gris verdoso
-          sec2: "#ead4ff", // lila claro
-          sec3: "#5d3f3c", // vino/marrón
-          sec4: "#f2ede1", // beige
+          "primary-1": "#18240f", // verde oscuro
+          "primary-2": "#fffffa", // crema (casi blanco)
+          "sec-1": "#afb6a6", // gris verdoso
+          "sec-2": "#ead4ff", // lila claro
+          "sec-3": "#5d3f3c", // vino/marrón
+          "sec-4": "#f2ede1", // beige
         },
         // shadcn/ui theme
         primary: "#18240f",


### PR DESCRIPTION
## Summary
- rename lp color tokens to hyphenated keys
- update components to use new hyphenated classes

## Testing
- `npm run lint`
- `npm run build`
- `rg -o 'bg-lp-primary-2' -n .next | head -n 20`
- `rg -o 'text-lp-sec-3' -n .next | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68a59429d698832fb8a0da0659253f99