### PR TITLE
refactor landing sections to allow configurable backgrounds

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,24 +10,12 @@ export default function Home() {
   return (
     <>
       <Hero />
-      <section className="py-20 bg-lp-sec-4">
-        <HowItWorks />
-      </section>
-      <section className="py-20">
-        <Benefits />
-      </section>
-      <section className="py-20 bg-lp-sec-4">
-        <TrustMetrics />
-      </section>
-      <section className="py-20">
-        <Allies />
-      </section>
-      <section className="py-20 bg-lp-sec-4">
-        <Testimonials />
-      </section>
-      <section className="py-20">
-        <Faq />
-      </section>
+      <HowItWorks backgroundClass="bg-lp-sec-4" />
+      <Benefits backgroundClass="bg-lp-sec-4" />
+      <TrustMetrics backgroundClass="bg-lp-primary-2" />
+      <Allies backgroundClass="bg-lp-primary-2" />
+      <Testimonials backgroundClass="bg-lp-sec-2" />
+      <Faq backgroundClass="bg-lp-primary-2" />
     </>
   );
 }

--- a/src/components/landing/Allies.tsx
+++ b/src/components/landing/Allies.tsx
@@ -1,3 +1,5 @@
+import { cn } from "@/lib/utils";
+
 const allies = [
   'Colombia Fintech',
   'ISO 27001 (en proceso)',
@@ -6,9 +8,13 @@ const allies = [
   'CCB',
 ];
 
-export function Allies() {
+interface AlliesProps {
+  backgroundClass?: string;
+}
+
+export function Allies({ backgroundClass = "" }: AlliesProps) {
   return (
-    <section className="py-20 sm:py-24 bg-lp-primary-2">
+    <section className={cn("py-20 sm:py-24", backgroundClass)}>
       <div className="container mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <h2 className="text-center font-colette text-2xl font-semibold leading-8 text-lp-primary-1">
           Con la confianza y el respaldo de

--- a/src/components/landing/Benefits.tsx
+++ b/src/components/landing/Benefits.tsx
@@ -7,6 +7,7 @@ import {
   LifeBuoy,
   type LucideIcon,
 } from 'lucide-react';
+import { cn } from "@/lib/utils";
 
 const benefits: {
   name: string;
@@ -51,9 +52,13 @@ const benefits: {
   },
 ];
 
-export function Benefits() {
+interface BenefitsProps {
+  backgroundClass?: string;
+}
+
+export function Benefits({ backgroundClass = "" }: BenefitsProps) {
   return (
-    <section className="py-20 sm:py-32 bg-lp-sec-4">
+    <section className={cn("py-20 sm:py-32", backgroundClass)}>
       <div className="container mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <div className="text-center">
           <h2 className="font-colette text-3xl font-bold tracking-tight text-lp-primary-1 sm:text-4xl">

--- a/src/components/landing/Faq.tsx
+++ b/src/components/landing/Faq.tsx
@@ -4,6 +4,7 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from "@/components/ui/accordion";
+import { cn } from "@/lib/utils";
 
 const faqs = [
   {
@@ -28,9 +29,13 @@ const faqs = [
   },
 ];
 
-export function Faq() {
+interface FaqProps {
+  backgroundClass?: string;
+}
+
+export function Faq({ backgroundClass = "" }: FaqProps) {
   return (
-    <section className="py-20 sm:py-32 bg-lp-primary-2">
+    <section className={cn("py-20 sm:py-32", backgroundClass)}>
       <div className="container mx-auto max-w-3xl px-4 sm:px-6 lg:px-8">
         <div className="text-center">
           <h2 className="font-colette text-3xl font-bold tracking-tight text-lp-primary-1 sm:text-4xl">

--- a/src/components/landing/HowItWorks.tsx
+++ b/src/components/landing/HowItWorks.tsx
@@ -1,4 +1,5 @@
 import { Card, CardContent } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
 
 const steps = [
   {
@@ -18,9 +19,13 @@ const steps = [
   },
 ];
 
-export function HowItWorks() {
+interface HowItWorksProps {
+  backgroundClass?: string;
+}
+
+export function HowItWorks({ backgroundClass = "" }: HowItWorksProps) {
   return (
-    <section className="py-20 sm:py-32 bg-lp-sec-4">
+    <section className={cn("py-20 sm:py-32", backgroundClass)}>
       <div className="container mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <div className="text-center">
           <h2 className="font-colette text-3xl font-bold tracking-tight text-lp-primary-1 sm:text-4xl">

--- a/src/components/landing/Testimonials.tsx
+++ b/src/components/landing/Testimonials.tsx
@@ -1,4 +1,5 @@
 import { Card, CardContent } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
 import {
   Carousel,
   CarouselContent,
@@ -25,9 +26,13 @@ const testimonials = [
   },
 ];
 
-export function Testimonials() {
+interface TestimonialsProps {
+  backgroundClass?: string;
+}
+
+export function Testimonials({ backgroundClass = "" }: TestimonialsProps) {
   return (
-    <section className="py-20 sm:py-32 bg-lp-sec-2">
+    <section className={cn("py-20 sm:py-32", backgroundClass)}>
       <div className="container mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <div className="text-center">
           <h2 className="font-colette text-3xl font-bold tracking-tight text-neutral-800 sm:text-4xl">

--- a/src/components/landing/TrustMetrics.tsx
+++ b/src/components/landing/TrustMetrics.tsx
@@ -1,3 +1,5 @@
+import { cn } from "@/lib/utils";
+
 const metrics = [
   { name: 'Facturas financiadas', value: '+1,200' },
   { name: 'Fondos desembolsados', value: '+$15M' },
@@ -5,9 +7,13 @@ const metrics = [
   { name: 'Tiempo de aprobación', value: '<24h' },
 ];
 
-export function TrustMetrics() {
+interface TrustMetricsProps {
+  backgroundClass?: string;
+}
+
+export function TrustMetrics({ backgroundClass = "" }: TrustMetricsProps) {
   return (
-    <section className="py-20 sm:py-32 bg-lp-primary-2">
+    <section className={cn("py-20 sm:py-32", backgroundClass)}>
       <div className="container mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <div className="grid grid-cols-1 gap-x-8 gap-y-16 text-center lg:grid-cols-4">
           {metrics.map((metric) => (


### PR DESCRIPTION
## Summary
- allow landing components to accept optional `backgroundClass` prop instead of fixed `bg-lp-*` sections
- set section backgrounds in `page.tsx` via new props

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5978d27e4832fa493cf5d6015093c