### PR TITLE
feat(navbar): center navigation links

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -35,14 +35,14 @@ export function Navbar() {
   return (
     <>
       <header className="sticky top-0 z-50 w-full border-b border-lp-sec-4/50 bg-lp-primary-1 backdrop-blur-sm">
-        <div className="container mx-auto flex h-16 max-w-7xl items-center justify-between px-4 sm:px-6 lg:px-8">
-          <Link href="/" className="flex items-center space-x-2" onClick={() => setIsMenuOpen(false)}>
+        <div className="container mx-auto grid h-16 max-w-7xl grid-cols-3 items-center px-4 sm:px-6 lg:px-8">
+          <Link href="/" className="flex items-center justify-start space-x-2" onClick={() => setIsMenuOpen(false)}>
             <Logo />
             <Image src="/LePretSinFondo.png" alt="LePrêt Capital" width={281} height={281} className="mt-[-15px]" />
           </Link>
-          
+
           {/* Desktop Navigation */}
-          <nav className="hidden items-center space-x-6 md:flex">
+          <nav className="hidden items-center justify-center space-x-6 md:flex">
             {navLinks.map((link) => (
               <Link key={link.href} href={link.href} className="text-sm font-medium text-lp-primary-2/80 transition-colors hover:text-lp-primary-2">
                 {link.label}
@@ -50,7 +50,7 @@ export function Navbar() {
             ))}
           </nav>
 
-          <div className="flex items-center space-x-4">
+          <div className="flex items-center justify-end space-x-4">
             <div className="hidden md:block">
               <Button asChild className="text-lp-primary-2">
                 <Link href="/preaprobacion">Conocer mi cupo</Link>


### PR DESCRIPTION
## Summary
- center desktop navigation links by switching navbar layout to a three-column grid

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a60fd84de0832fb72ba2346d2e9263