### PR TITLE
Improve navbar link contrast

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -47,7 +47,7 @@ export function Navbar() {
               <Link
                 key={link.href}
                 href={link.href}
-                className="rounded-md px-3 py-2 text-sm font-medium text-lp-primary-2/80 transition-colors hover:bg-lp-primary-2/10 hover:text-lp-primary-2"
+                className="rounded-md px-3 py-2 text-sm font-medium text-lp-primary-2 transition-colors hover:bg-lp-primary-2 hover:text-lp-primary-1"
               >
                 {link.label}
               </Link>


### PR DESCRIPTION
## Summary
- increase default navigation link opacity for better readability
- invert hover colors to preserve accessibility contrast

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6ffaf1114832f8906b523d160377e