### PR TITLE
Use root HTML element for custom fonts

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,28 +7,20 @@ import { Footer } from "@/components/Footer";
 // Font configuration
 const colette = localFont({
   src: [
-    { path: '../../public/fonts/colette/Colette-Thin.otf', weight: '100', style: 'normal' },
-    { path: '../../public/fonts/colette/Colette-Light.otf', weight: '300', style: 'normal' },
-    { path: '../../public/fonts/colette/Colette-Regular.otf', weight: '400', style: 'normal' },
-    { path: '../../public/fonts/colette/Colette-LightItalic.otf', weight: '300', style: 'italic' },
-    { path: '../../public/fonts/colette/Colette-Bold.otf', weight: '700', style: 'normal' },
-    { path: '../../public/fonts/colette/Colette-BoldItalic.otf', weight: '700', style: 'italic' },
-    { path: '../../public/fonts/colette/Colette-Black.otf', weight: '900', style: 'normal' },
-    { path: '../../public/fonts/colette/Colette-BlackItalic.otf', weight: '900', style: 'italic' },
+    { path: "../../public/fonts/colette/Colette-Bold.otf", weight: "700", style: "normal" },
+    { path: "../../public/fonts/colette/Colette-Regular.otf", weight: "400", style: "normal" },
   ],
-  variable: '--font-colette',
-  display: 'swap',
+  variable: "--font-colette",
+  display: "swap",
 });
 
 const kollektif = localFont({
   src: [
-    { path: '../../public/fonts/kollektif/Kollektif.ttf', weight: '400', style: 'normal' },
-    { path: '../../public/fonts/kollektif/Kollektif-Italic.ttf', weight: '400', style: 'italic' },
-    { path: '../../public/fonts/kollektif/Kollektif-Bold.ttf', weight: '700', style: 'normal' },
-    { path: '../../public/fonts/kollektif/Kollektif-BoldItalic.ttf', weight: '700', style: 'italic' },
+    { path: "../../public/fonts/kollektif/Kollektif.ttf", weight: "400", style: "normal" },
+    { path: "../../public/fonts/kollektif/Kollektif-Bold.ttf", weight: "700", style: "normal" },
   ],
-  variable: '--font-kollektif',
-  display: 'swap',
+  variable: "--font-kollektif",
+  display: "swap",
 });
 
 export const metadata: Metadata = {
@@ -36,14 +28,10 @@ export const metadata: Metadata = {
   description: "Proceso 100% en línea. Preaprobación en minutos. Desembolso ágil. Sin afectar tu capacidad de crédito.",
 };
 
-export default function RootLayout({
-  children,
-}: Readonly<{
-  children: React.ReactNode;
-}>) {
+export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="es">
-      <body className={`${colette.variable} ${kollektif.variable} antialiased`}>
+    <html lang="es" className={`${colette.variable} ${kollektif.variable}`}>
+      <body className="antialiased">
         <div className="flex min-h-screen flex-col">
           <Navbar />
           <main className="flex-grow">{children}</main>


### PR DESCRIPTION
## Summary
- simplify Colette and Kollektif font definitions
- apply font variables on the `<html>` root element

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: Missing API key)*

------
https://chatgpt.com/codex/tasks/task_e_68a7151696ec832fa907e5f8ba35a6b7