### PR TITLE
feat: add security headers

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,49 @@
 import type { NextConfig } from "next";
 
+const ContentSecurityPolicy = [
+  "default-src 'self'",
+  "frame-ancestors 'none'",
+  "object-src 'none'",
+  "base-uri 'self'",
+  "form-action 'self'",
+  "script-src 'self'",
+  "style-src 'self'",
+  "img-src 'self' data:",
+  "font-src 'self'",
+].join("; ");
+
+const securityHeaders = [
+  {
+    key: "Content-Security-Policy",
+    value: ContentSecurityPolicy,
+  },
+  {
+    key: "Strict-Transport-Security",
+    value: "max-age=63072000; includeSubDomains; preload",
+  },
+  {
+    key: "X-Content-Type-Options",
+    value: "nosniff",
+  },
+  {
+    key: "X-Frame-Options",
+    value: "DENY",
+  },
+  {
+    key: "Referrer-Policy",
+    value: "no-referrer",
+  },
+];
+
 const nextConfig: NextConfig = {
-  /* config options here */
+  async headers() {
+    return [
+      {
+        source: "/(.*)",
+        headers: securityHeaders,
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- add restrictive security headers via `next.config.ts`
- include CSP, HSTS, X-Content-Type-Options, X-Frame-Options, and Referrer-Policy

## Testing
- `npm run lint`
- `npm run build`
- `curl -I http://localhost:3000`


------
https://chatgpt.com/codex/tasks/task_e_68a87bcba0b8832fbdb17514e2b858e3