### PR TITLE
Sanitize user input in API routes

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "react-dom": "19.1.0",
     "react-hook-form": "^7.62.0",
     "resend": "^6.0.1",
+    "sanitize-html": "^2.12.1",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.3.1",
     "zod": "^4.0.17"

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from 'next/server';
 import { ContactValidator } from '@/lib/validators/contact';
 import { z } from 'zod';
 import { Resend } from 'resend';
+import sanitizeHtml from 'sanitize-html';
 
 const resend = new Resend(process.env.RESEND_API_KEY);
 
@@ -10,16 +11,20 @@ export async function POST(req: Request) {
   try {
     const body = await req.json();
     const { nombre, email, telefono, mensaje } = ContactValidator.parse(body);
+    const safeNombre = sanitizeHtml(nombre);
+    const safeEmail = sanitizeHtml(email);
+    const safeTelefono = telefono ? sanitizeHtml(telefono) : undefined;
+    const safeMensaje = sanitizeHtml(mensaje);
 
     await resend.emails.send({
       from: 'onboarding@resend.dev',
-      to: [email, 'admin@lepret.co'],
-      subject: `Nuevo Mensaje de Contacto de ${nombre}`,
-      html: `<p><strong>Nombre:</strong> ${nombre}</p>
-             <p><strong>Email:</strong> ${email}</p>
-             <p><strong>Teléfono:</strong> ${telefono || 'No proporcionado'}</p>
+      to: [safeEmail, 'admin@lepret.co'],
+      subject: `Nuevo Mensaje de Contacto de ${safeNombre}`,
+      html: `<p><strong>Nombre:</strong> ${safeNombre}</p>
+             <p><strong>Email:</strong> ${safeEmail}</p>
+             <p><strong>Teléfono:</strong> ${safeTelefono || 'No proporcionado'}</p>
              <p><strong>Mensaje:</strong></p>
-             <p>${mensaje}</p>`
+             <p>${safeMensaje}</p>`
     });
 
     return NextResponse.json({ message: 'Mensaje enviado con éxito. Nos pondremos en contacto contigo pronto.' });


### PR DESCRIPTION
## Summary
- add sanitize-html dependency
- sanitize contact and preapproval fields before constructing HTML

## Testing
- `npm run lint`
- `npm test` (fails: Missing script "test")
- `npm install sanitize-html` (fails: 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_68a87bba6738832f8efefd080c52dd5a