### PR TITLE
feat: centralize environment validation

### DIFF
--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -3,8 +3,9 @@ import { NextResponse } from 'next/server';
 import { ContactValidator } from '@/lib/validators/contact';
 import { z } from 'zod';
 import { Resend } from 'resend';
+import { env } from '@/lib/env';
 
-const resend = new Resend(process.env.RESEND_API_KEY);
+const resend = new Resend(env.RESEND_API_KEY);
 
 export async function POST(req: Request) {
   try {

--- a/src/app/api/preapproval/route.ts
+++ b/src/app/api/preapproval/route.ts
@@ -4,8 +4,9 @@ import { prisma } from '@/lib/prisma';
 import { PreapprovalValidator } from '@/lib/validators/preapproval';
 import { z } from 'zod';
 import { Resend } from 'resend';
+import { env } from '@/lib/env';
 
-const resend = new Resend(process.env.RESEND_API_KEY);
+const resend = new Resend(env.RESEND_API_KEY);
 
 // Dummy business logic for credit line estimation
 function calculateCupo(ventasAnuales: number, ticketPromedio: number, facturasMes: number): number {

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+const envSchema = z.object({
+  DATABASE_URL: z.string().url(),
+  RESEND_API_KEY: z.string().min(1),
+  NODE_ENV: z.enum(['development', 'test', 'production']).default('development'),
+});
+
+const _env = envSchema.safeParse(process.env);
+
+if (!_env.success) {
+  const missing = Object.keys(_env.error.flatten().fieldErrors)
+    .map((key) => `${key}`)
+    .join(', ');
+  console.error('❌ Invalid environment variables:', _env.error.flatten().fieldErrors);
+  throw new Error(`Missing environment variables: ${missing}`);
+}
+
+export const env = _env.data;

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,4 +1,5 @@
 import { PrismaClient } from '@prisma/client';
+import { env } from '@/lib/env';
 
 declare global {
   // allow global `var` declarations
@@ -8,7 +9,7 @@ declare global {
 export const prisma =
   global.prisma ||
   new PrismaClient({
-    log: process.env.NODE_ENV === 'development' ? ['query'] : [],
+    log: env.NODE_ENV === 'development' ? ['query'] : [],
   });
 
-if (process.env.NODE_ENV !== 'production') global.prisma = prisma;
+if (env.NODE_ENV !== 'production') global.prisma = prisma;


### PR DESCRIPTION
## Summary
- add Zod-based env schema for required DATABASE_URL and RESEND_API_KEY
- use env module instead of process.env in API routes and Prisma
- throw clear error when required env vars are missing

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a87bd2e034832fbbebd09ad0f3e3c4