### PR TITLE
feat: enforce unique NIT for lead

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,6 +20,7 @@ model Lead {
   source        String? // web, referral, ads
   consent       Boolean
   preapproval   Preapproval?
+  @@unique([nit])
 }
 
 model Preapproval {


### PR DESCRIPTION
## Summary
- ensure `Lead.nit` is unique in prisma schema
- handle Prisma P2002 errors in preapproval route with a generic message

## Testing
- `npx prisma migrate dev --name unique_nit` *(fails: Can't reach database server at `localhost:5432`)*
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a87bdc8964832fac2dcdbf706c78b0