### PR TITLE
Validate numeric NIT input

### DIFF
--- a/src/components/forms/PreApprovalForm.tsx
+++ b/src/components/forms/PreApprovalForm.tsx
@@ -94,7 +94,13 @@ export function PreApprovalForm() {
         <div className="grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-2">
           <div>
             <Label htmlFor="nit" className="mb-2">NIT</Label>
-            <Input id="nit" autoComplete="off" {...form.register("nit")} />
+            <Input
+              id="nit"
+              autoComplete="off"
+              inputMode="numeric"
+              pattern="[0-9]*"
+              {...form.register("nit")}
+            />
             <FormError
               message={form.formState.errors.nit?.message}
               className="mt-1"

--- a/src/lib/validators/preapproval.test.ts
+++ b/src/lib/validators/preapproval.test.ts
@@ -1,0 +1,37 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { PreapprovalValidator } from './preapproval';
+
+const baseData = {
+  nit: '12345',
+  razonSocial: '',
+  ventasAnuales: 1,
+  facturasMes: 0,
+  ticketPromedio: 1,
+  email: 'test@example.com',
+  telefono: '',
+  consent: true,
+};
+
+describe('PreapprovalValidator nit', () => {
+  it('accepts at least five numeric characters', () => {
+    const result = PreapprovalValidator.safeParse(baseData);
+    assert.ok(result.success);
+  });
+
+  it('rejects non-numeric characters', () => {
+    const result = PreapprovalValidator.safeParse({ ...baseData, nit: '12a45' });
+    assert.ok(!result.success);
+    if (!result.success) {
+      assert.ok(result.error.format().nit?._errors.includes('NIT inválido'));
+    }
+  });
+
+  it('rejects fewer than five digits', () => {
+    const result = PreapprovalValidator.safeParse({ ...baseData, nit: '1234' });
+    assert.ok(!result.success);
+    if (!result.success) {
+      assert.ok(result.error.format().nit?._errors.includes('NIT inválido'));
+    }
+  });
+});

--- a/src/lib/validators/preapproval.ts
+++ b/src/lib/validators/preapproval.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
 export const PreapprovalValidator = z.object({
-  nit: z.string().min(5, "NIT inválido"),
+  nit: z.string().regex(/^[0-9]{5,}$/, "NIT inválido"),
   razonSocial: z.string().optional().default(""),
   ventasAnuales: z.coerce.number().positive("Ingresa un valor válido"),
   facturasMes: z.coerce.number().int().nonnegative("Ingresa un entero válido"),


### PR DESCRIPTION
## Summary
- ensure preapproval validator only accepts numeric NIT values
- restrict NIT input field to numeric characters on the frontend
- add tests covering new NIT validation rules

## Testing
- `npm run lint`
- `node --test build-tests/preapproval.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68a87be3650c832fa2019879283bfcb2