### PR TITLE
Add basic rate limiting and CSRF protection to API routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,15 @@ Este proyecto está optimizado para despliegue en Vercel.
 
 La lógica para calcular el `cupoEstimado` se encuentra en el archivo `src/app/api/preapproval/route.ts`, dentro de la función `calculateCupo`. Puedes modificar esta función para ajustar las reglas de negocio según sea necesario.
 
+## Respuestas de Error de la API
+
+Las rutas `/api/contact` y `/api/preapproval` devuelven códigos de error cuando la solicitud no pasa las verificaciones.
+
+* **429 Too Many Requests** – Se excedió el límite de peticiones.  
+  Respuesta: `{ "message": "Demasiadas solicitudes." }`
+* **403 Forbidden** – La cabecera `Origin` o `Referer` no coincide con el host permitido.  
+  Respuesta: `{ "message": "Operación no permitida." }`
+
 ## Estructura de Directorios Clave
 
 *   `src/app`: Rutas de Next.js (páginas y API routes).

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -3,10 +3,27 @@ import { NextResponse } from 'next/server';
 import { ContactValidator } from '@/lib/validators/contact';
 import { z } from 'zod';
 import { Resend } from 'resend';
+import { isRateLimited } from '@/lib/ratelimit';
+import { isValidOrigin } from '@/lib/security';
 
 const resend = new Resend(process.env.RESEND_API_KEY);
 
 export async function POST(req: Request) {
+  const ip = req.headers.get('x-forwarded-for') ?? 'unknown';
+  if (isRateLimited(ip)) {
+    return new NextResponse(
+      JSON.stringify({ message: 'Demasiadas solicitudes.' }),
+      { status: 429 }
+    );
+  }
+
+  if (!isValidOrigin(req)) {
+    return new NextResponse(
+      JSON.stringify({ message: 'Operación no permitida.' }),
+      { status: 403 }
+    );
+  }
+
   try {
     const body = await req.json();
     const { nombre, email, telefono, mensaje } = ContactValidator.parse(body);

--- a/src/app/api/preapproval/route.ts
+++ b/src/app/api/preapproval/route.ts
@@ -4,6 +4,8 @@ import { prisma } from '@/lib/prisma';
 import { PreapprovalValidator } from '@/lib/validators/preapproval';
 import { z } from 'zod';
 import { Resend } from 'resend';
+import { isRateLimited } from '@/lib/ratelimit';
+import { isValidOrigin } from '@/lib/security';
 
 const resend = new Resend(process.env.RESEND_API_KEY);
 
@@ -21,6 +23,21 @@ function calculateCupo(ventasAnuales: number, ticketPromedio: number, facturasMe
 }
 
 export async function POST(req: Request) {
+  const ip = req.headers.get('x-forwarded-for') ?? 'unknown';
+  if (isRateLimited(ip)) {
+    return new NextResponse(
+      JSON.stringify({ message: 'Demasiadas solicitudes.' }),
+      { status: 429 }
+    );
+  }
+
+  if (!isValidOrigin(req)) {
+    return new NextResponse(
+      JSON.stringify({ message: 'Operación no permitida.' }),
+      { status: 403 }
+    );
+  }
+
   try {
     const body = await req.json();
     const validatedData = PreapprovalValidator.parse(body);

--- a/src/lib/ratelimit.ts
+++ b/src/lib/ratelimit.ts
@@ -1,0 +1,26 @@
+const WINDOW = 60 * 1000; // 1 minute
+const MAX_REQUESTS = 5;
+
+interface Entry {
+  count: number;
+  expires: number;
+}
+
+const store = new Map<string, Entry>();
+
+export function isRateLimited(ip: string): boolean {
+  const now = Date.now();
+  const entry = store.get(ip);
+
+  if (!entry || entry.expires < now) {
+    store.set(ip, { count: 1, expires: now + WINDOW });
+    return false;
+  }
+
+  if (entry.count >= MAX_REQUESTS) {
+    return true;
+  }
+
+  entry.count += 1;
+  return false;
+}

--- a/src/lib/security.ts
+++ b/src/lib/security.ts
@@ -1,0 +1,23 @@
+export function isValidOrigin(req: Request): boolean {
+  const origin = req.headers.get('origin');
+  const referer = req.headers.get('referer');
+  const host = new URL(req.url).origin;
+
+  if (origin) {
+    try {
+      return origin === host;
+    } catch {
+      return false;
+    }
+  }
+
+  if (referer) {
+    try {
+      return new URL(referer).origin === host;
+    } catch {
+      return false;
+    }
+  }
+
+  return false;
+}


### PR DESCRIPTION
## Summary
- implement simple in-memory rate limiter for API routes
- verify Origin/Referer headers before processing requests
- document 403 and 429 error responses

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a87bf3a780832fb638067c1360395a