### PR TITLE
Return message from contact API and surface in form

### DIFF
--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -58,7 +58,7 @@ export async function POST(req: Request) {
 
     // (Opcional) mantener aquí el envío de email con Resend si ya existe
 
-    return NextResponse.json({ ok: true });
+    return NextResponse.json({ ok: true, message: "Mensaje recibido" });
   } catch (e: unknown) {
     const error = e instanceof Error ? e.message : String(e);
     return NextResponse.json({ ok: false, error }, { status: 500 });

--- a/src/components/forms/ContactForm.tsx
+++ b/src/components/forms/ContactForm.tsx
@@ -37,10 +37,14 @@ export function ContactForm() {
       const responseData = await response.json();
 
       if (!response.ok) {
-        throw new Error(responseData.message || 'Ocurrió un error al enviar el mensaje.');
+        throw new Error(
+          responseData.error ||
+            responseData.message ||
+            'Ocurrió un error al enviar el mensaje.'
+        );
       }
 
-      toast.success(responseData.message);
+      toast.success(responseData.message || 'Mensaje recibido');
       form.reset();
 
     } catch (err) {


### PR DESCRIPTION
## Summary
- include `message` in successful `/api/contact` response
- surface server message in `ContactForm` and improve error handling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad4b49cd60832fb19564cea67cc5cc