### PR TITLE
Fix contact form API validation for required fields

### DIFF
--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -17,7 +17,7 @@ export async function POST(req: Request) {
     const mensaje  = body.message ?? body.mensaje ?? null;
     const consent  = body.consent ?? body.accepted_privacy ?? false;
 
-    if (!nombre || !email || !consent) {
+    if (!nombre || !email || !mensaje) {
       return NextResponse.json(
         { ok: false, error: "Faltan campos obligatorios." },
         { status: 400 }


### PR DESCRIPTION
## Summary
- remove consent from required fields in contact API
- require message field to align with frontend form

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad55c79a74832f8f3e151b652057c3