### PR TITLE
Fix type mismatch in invoice upload form

### DIFF
--- a/src/app/c/[orgId]/invoices/ui/InvoiceUploadForm.tsx
+++ b/src/app/c/[orgId]/invoices/ui/InvoiceUploadForm.tsx
@@ -2,7 +2,7 @@
 
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { InvoiceUploadValidator, InvoiceUploadRequest, InvoiceUploadFormInput } from '@/lib/validators/invoice';
+import { InvoiceUploadValidator, InvoiceUploadRequest } from '@/lib/validators/invoice';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -14,12 +14,11 @@ export function InvoiceUploadForm({ orgId }: { orgId: string }) {
   console.log('orgId', orgId); // Use orgId to remove warning
   const [isLoading, setIsLoading] = useState<boolean>(false);
 
-  const form = useForm<InvoiceUploadFormInput>({
+  const form = useForm<InvoiceUploadRequest>({
     resolver: zodResolver(InvoiceUploadValidator),
     defaultValues: {
       invoiceNumber: '',
       amount: 0,
-      dueDate: '',
       file: undefined,
     },
   });
@@ -49,7 +48,7 @@ export function InvoiceUploadForm({ orgId }: { orgId: string }) {
 
       <div>
         <Label htmlFor="dueDate" className="mb-2">Fecha de Vencimiento</Label>
-        <Input id="dueDate" type="date" {...form.register('dueDate')} />
+        <Input id="dueDate" type="date" {...form.register('dueDate', { valueAsDate: true })} />
         <FormError message={form.formState.errors.dueDate?.message} className="mt-1" />
       </div>
 
@@ -59,7 +58,12 @@ export function InvoiceUploadForm({ orgId }: { orgId: string }) {
           id="file"
           type="file"
           accept="application/pdf,image/jpeg,image/png"
-          onChange={(e) => form.setValue('file', e.target.files?.[0] || undefined, { shouldValidate: true })}
+          onChange={(e) => {
+            const file = e.target.files?.[0];
+            if (file) {
+              form.setValue('file', file, { shouldValidate: true });
+            }
+          }}
         />
         <FormError message={form.formState.errors.file?.message} className="mt-1" />
       </div>

--- a/src/lib/validators/invoice.ts
+++ b/src/lib/validators/invoice.ts
@@ -17,11 +17,3 @@ export const InvoiceUploadValidator = z.object({
 });
 
 export type InvoiceUploadRequest = z.infer<typeof InvoiceUploadValidator>;
-
-// Define the input type for the form before Zod coercion
-export type InvoiceUploadFormInput = {
-  invoiceNumber: string;
-  amount: string | number; // Input can be string from form field
-  dueDate: string | Date; // Input can be string from form field
-  file: File | undefined; // Input can be undefined if no file is selected
-};


### PR DESCRIPTION
## Summary
- Align invoice upload form with Zod resolver using `InvoiceUploadRequest`
- Simplify invoice validator by removing unused input type

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Module not found `@radix-ui/react-dialog`)*

------
https://chatgpt.com/codex/tasks/task_e_68c662e705f8832fbc3f26177d8eaf05