### PR TITLE
fix: update secondary palette color

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,7 +5,7 @@
   --color-lp-primary-1: #18240f; /* VERDE OSCURO (Color Principal 1) */
   --color-lp-primary-2: #fffffa; /* CREMA (Color Principal 2) */
   --color-lp-sec-1: #afb6a6;     /* Gris verdoso */
-  --color-lp-sec-2: #afb6a6;     /* Gris verdoso */
+  --color-lp-sec-2: #ead4ff;     /* Lavanda */
   --color-lp-sec-3: #5d3f3c;     /* Vino/Marrón */
   --color-lp-sec-4: #f2ede1;     /* Beige */
 


### PR DESCRIPTION
## Summary
- differentiate secondary palette colors by changing `--color-lp-sec-2` to brand lavender (#ead4ff)

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c6f9afe3a0832faf7628201103b4cb