### PR TITLE
feat(ui): improve button contrast

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -9,6 +9,13 @@
   --color-lp-sec-3: #5d3f3c;     /* Vino/Marrón */
   --color-lp-sec-4: #f2ede1;     /* Beige */
 
+  /* Button colors */
+  --button-primary: var(--color-lp-primary-1);
+  --button-primary-foreground: var(--color-lp-primary-2);
+  --button-primary-hover: #2f3a26; /* 90% mix of primary with background */
+  --button-primary-disabled: #8c9285;
+  --button-primary-disabled-foreground: var(--color-lp-primary-1);
+
   /* Shadcn/ui theme variables */
   --color-background: var(--color-lp-primary-2);
   --color-foreground: var(--color-lp-primary-1);

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,12 +5,12 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
     variants: {
       variant: {
         default:
-          "bg-primary text-primary-foreground shadow-xs hover:bg-primary/90",
+          "bg-[var(--button-primary)] text-[var(--button-primary-foreground)] shadow-xs hover:bg-[var(--button-primary-hover)] disabled:bg-[var(--button-primary-disabled)] disabled:text-[var(--button-primary-disabled-foreground)] disabled:opacity-100",
         destructive:
           "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
         outline:


### PR DESCRIPTION
## Summary
- add dedicated button color tokens in global styles
- use high-contrast tokens for default, hover and disabled button states

## Testing
- `npm run lint`
- `node -e "function lum(hex){const rgb=hex.replace('#','').match(/.{2}/g).map(x=>parseInt(x,16)/255).map(v=>v<=0.03928?v/12.92:Math.pow((v+0.055)/1.055,2.4));return 0.2126*rgb[0]+0.7152*rgb[1]+0.0722*rgb[2];}function contrast(c1,c2){const L1=lum(c1);const L2=lum(c2);const [max,min]=L1>L2?[L1,L2]:[L2,L1];return (max+0.05)/(min+0.05);}const def=contrast('#18240f','#fffffa');const hover=contrast('#2f3a26','#fffffa');const dis=contrast('#8c9285','#18240f');console.log('default',def.toFixed(2),'hover',hover.toFixed(2),'disabled',dis.toFixed(2));"`

------
https://chatgpt.com/codex/tasks/task_e_68c7028f9c9c832f906e91d703509802