### PR TITLE
Mostrar nombre de empresa en cabecera del portal

### DIFF
--- a/src/app/c/[orgId]/layout.tsx
+++ b/src/app/c/[orgId]/layout.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { supabaseServer } from "@/lib/supabase-server";
 
 export default async function ClientPortalLayout({
   children,
@@ -8,6 +9,52 @@ export default async function ClientPortalLayout({
   params: Promise<{ orgId: string }>;
 }) {
   const { orgId } = await params;
+
+  const supabase = await supabaseServer();
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  const extractCompanyName = (companies: unknown): string | null => {
+    if (!companies) return null;
+    if (Array.isArray(companies)) {
+      const [first] = companies;
+      if (first && typeof first === "object" && "name" in first) {
+        const value = (first as { name?: unknown }).name;
+        return typeof value === "string" ? value : null;
+      }
+      return null;
+    }
+    if (typeof companies === "object" && "name" in companies) {
+      const value = (companies as { name?: unknown }).name;
+      return typeof value === "string" ? value : null;
+    }
+    return null;
+  };
+
+  let orgName: string | null = null;
+
+  if (session) {
+    const { data: membership } = await supabase
+      .from("memberships")
+      .select("companies(name)")
+      .eq("company_id", orgId)
+      .eq("user_id", session.user.id)
+      .maybeSingle();
+
+    orgName = extractCompanyName(membership?.companies);
+
+    if (!orgName) {
+      const { data: company } = await supabase
+        .from("companies")
+        .select("name")
+        .eq("id", orgId)
+        .maybeSingle();
+      orgName = typeof company?.name === "string" ? company.name : null;
+    }
+  }
+
+  const displayOrg = orgName ?? orgId;
 
   const links = [
     { href: `/c/${orgId}`, label: "Resumen" },
@@ -22,7 +69,7 @@ export default async function ClientPortalLayout({
         <div className="mb-6 flex flex-wrap items-center gap-3 text-sm text-lp-sec-3">
           <span className="font-semibold text-lp-primary-1">Portal Clientes</span>
           <span className="opacity-60">/</span>
-          <span className="truncate">Org: {orgId}</span>
+          <span className="truncate">Org: {displayOrg}</span>
         </div>
 
         <nav className="mb-8 flex flex-wrap gap-2">


### PR DESCRIPTION
## Summary
- obtiene el nombre de la organización para el layout del portal de clientes y lo muestra en lugar del id

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c83c97076c832f856a8335b330a976