### PR TITLE
Fix hero image layout

### DIFF
--- a/src/components/landing/Hero.tsx
+++ b/src/components/landing/Hero.tsx
@@ -32,14 +32,16 @@ export function Hero() {
       <div className="mt-16 flow-root w-full sm:w-5/6 lg:w-5/6 mx-auto">
         <div className="rounded-2xl bg-lp-sec-4 p-2 ring-1 ring-inset ring-lp-sec-1/10 lg:p-4">
           <div className="bg-white rounded-xl shadow-2xl ring-1 ring-gray-900/10 overflow-hidden">
-            <Image
-              src="/Liquidez.png"
-              alt="Dashboard Mockup"
-              width={1024}
-              height={768}
-              priority
-              className="w-full h-auto object-contain max-h-[500px] mx-auto"
-            />
+            <div className="relative aspect-[4/3] w-full">
+              <Image
+                src="/Liquidez.png"
+                alt="Dashboard Mockup"
+                fill
+                priority
+                sizes="(min-width: 1280px) 53vw, (min-width: 640px) 70vw, 100vw"
+                className="object-cover"
+              />
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- ensure the hero dashboard mockup image fills its frame by using a fixed aspect ratio wrapper and Next.js fill images

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c84c579b28832fb09bbfcd5a526d97