### PR TITLE
Adjust hero image fit and testimonials background

### DIFF
--- a/src/components/landing/Hero.tsx
+++ b/src/components/landing/Hero.tsx
@@ -32,14 +32,16 @@ export function Hero() {
       <div className="mt-16 flow-root w-full sm:w-5/6 lg:w-5/6 mx-auto">
         <div className="rounded-2xl bg-lp-sec-4 p-2 ring-1 ring-inset ring-lp-sec-1/10 lg:p-4">
           <div className="bg-white rounded-xl shadow-2xl ring-1 ring-gray-900/10 overflow-hidden">
-            <Image
-              src="/Liquidez.png"
-              alt="Dashboard Mockup"
-              width={1024}
-              height={768}
-              priority
-              className="w-full h-auto object-contain max-h-[500px] mx-auto"
-            />
+            <div className="relative aspect-[4/3] w-full">
+              <Image
+                src="/Liquidez.png"
+                alt="Dashboard Mockup"
+                fill
+                priority
+                sizes="(min-width: 1280px) 53vw, (min-width: 640px) 70vw, 100vw"
+                className="object-contain"
+              />
+            </div>
           </div>
         </div>
       </div>

--- a/src/components/landing/Testimonials.tsx
+++ b/src/components/landing/Testimonials.tsx
@@ -30,9 +30,11 @@ interface TestimonialsProps {
   backgroundClass?: string;
 }
 
-export function Testimonials({ backgroundClass = "" }: TestimonialsProps) {
+export function Testimonials({ backgroundClass }: TestimonialsProps) {
   return (
-    <section className={cn("py-20 sm:py-32", backgroundClass)}>
+    <section
+      className={cn("py-20 sm:py-32 bg-lp-sec-2", backgroundClass)}
+    >
       <div className="container mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <div className="text-center">
           <h2 className="font-colette text-3xl font-bold tracking-tight text-neutral-800 sm:text-4xl">


### PR DESCRIPTION
## Summary
- ensure the hero dashboard mockup image fills its frame while preserving the full artwork by keeping the fixed aspect ratio wrapper with an object-contain fill
- ensure the testimonials section keeps its lavender background by default to match the main branch styling

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c84c579b28832fb09bbfcd5a526d97