### PR TITLE
Align landing hero and testimonials styling with main

### DIFF
--- a/src/components/landing/Hero.tsx
+++ b/src/components/landing/Hero.tsx
@@ -39,7 +39,7 @@ export function Hero() {
                 fill
                 priority
                 sizes="(min-width: 1280px) 53vw, (min-width: 640px) 70vw, 100vw"
-
+                className="object-cover"
               />
             </div>
           </div>

--- a/src/components/landing/Testimonials.tsx
+++ b/src/components/landing/Testimonials.tsx
@@ -30,11 +30,9 @@ interface TestimonialsProps {
   backgroundClass?: string;
 }
 
-export function Testimonials({ backgroundClass }: TestimonialsProps) {
+export function Testimonials({ backgroundClass = "" }: TestimonialsProps) {
   return (
-    <section
-      className={cn("py-20 sm:py-32 bg-lp-sec-2", backgroundClass)}
-    >
+    <section className={cn("py-20 sm:py-32", backgroundClass)}>
       <div className="container mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <div className="text-center">
           <h2 className="font-colette text-3xl font-bold tracking-tight text-neutral-800 sm:text-4xl">


### PR DESCRIPTION
## Summary
- add back the hero image `object-cover` class so the hero layout matches main
- restore the testimonials section to rely on the caller-provided background class instead of forcing a color

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c85652e854832fa6baf48701b2f507