### PR TITLE
Align landing hero and testimonials styling with main

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,7 +5,6 @@
   --color-lp-primary-1: #18240f; /* VERDE OSCURO (Color Principal 1) */
   --color-lp-primary-2: #fffffa; /* CREMA (Color Principal 2) */
   --color-lp-sec-1: #afb6a6;     /* Gris verdoso */
-  --color-lp-sec-2: #ead4ff;     /* Lavanda */
   --color-lp-sec-3: #5d3f3c;     /* Vino/Marrón */
   --color-lp-sec-4: #f2ede1;     /* Beige */
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,7 +12,7 @@ export default function Home() {
       <HowItWorks backgroundClass="bg-lp-sec-4" />
       <Benefits backgroundClass="bg-lp-sec-4" />
       <TrustMetrics backgroundClass="bg-lp-primary-2" />
-      <Testimonials backgroundClass="bg-lp-sec-2" />
+      <Testimonials />
       <Faq backgroundClass="bg-lp-primary-2" />
     </>
   );

--- a/src/components/landing/Hero.tsx
+++ b/src/components/landing/Hero.tsx
@@ -39,7 +39,7 @@ export function Hero() {
                 fill
                 priority
                 sizes="(min-width: 1280px) 53vw, (min-width: 640px) 70vw, 100vw"
-
+                className="object-cover"
               />
             </div>
           </div>

--- a/src/components/landing/Testimonials.tsx
+++ b/src/components/landing/Testimonials.tsx
@@ -30,11 +30,9 @@ interface TestimonialsProps {
   backgroundClass?: string;
 }
 
-export function Testimonials({ backgroundClass }: TestimonialsProps) {
+export function Testimonials({ backgroundClass = "" }: TestimonialsProps) {
   return (
-    <section
-      className={cn("py-20 sm:py-32 bg-lp-sec-2", backgroundClass)}
-    >
+    <section className={cn("py-20 sm:py-32", backgroundClass)}>
       <div className="container mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <div className="text-center">
           <h2 className="font-colette text-3xl font-bold tracking-tight text-neutral-800 sm:text-4xl">


### PR DESCRIPTION
## Summary
- add back the hero image `object-cover` class so the hero layout matches main
- remove the lavender testimonials background and the unused `lp-sec-2` token so the landing matches main's neutral palette

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c85652e854832fa6baf48701b2f507