### PR TITLE
Add autocomplete attributes to login form inputs

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -81,13 +81,27 @@ function LoginForm() {
         <form onSubmit={onSubmit} className="mt-6 space-y-6">
           <div>
             <Label htmlFor="email">Email</Label>
-            <Input id="email" type="email" value={email} onChange={(e) => setEmail(e.target.value)} required />
+            <Input
+              id="email"
+              type="email"
+              autoComplete="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+            />
           </div>
           {mode === 'password' && (
             <div>
               <Label htmlFor="password">Contraseña</Label>
               <div className="flex gap-2">
-                <Input id="password" type={showPw? 'text':'password'} value={password} onChange={(e) => setPassword(e.target.value)} required />
+                <Input
+                  id="password"
+                  type={showPw? 'text':'password'}
+                  autoComplete="current-password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  required
+                />
                 <Button type="button" variant="outline" onClick={()=>setShowPw(v=>!v)}>{showPw? 'Ocultar':'Ver'}</Button>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- set the login email field to use the browser autocomplete hint for email addresses
- mark the password field to use the current-password autocomplete hint
- confirmed the shared Input component forwards HTML props so the autocomplete values reach the DOM element

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c913940b8c832f82cb27c96393a510