### PR TITLE
Use icon for password visibility toggle

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -2,6 +2,7 @@
 
 import { Suspense, useEffect, useMemo, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
+import { Eye, EyeOff } from "lucide-react";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
@@ -88,7 +89,15 @@ function LoginForm() {
               <Label htmlFor="password">Contraseña</Label>
               <div className="flex gap-2">
                 <Input id="password" type={showPw? 'text':'password'} value={password} onChange={(e) => setPassword(e.target.value)} required />
-                <Button type="button" variant="outline" onClick={()=>setShowPw(v=>!v)}>{showPw? 'Ocultar':'Ver'}</Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon"
+                  onClick={() => setShowPw((v) => !v)}
+                  aria-label={showPw ? "Ocultar contraseña" : "Mostrar contraseña"}
+                >
+                  {showPw ? <EyeOff className="size-4" aria-hidden="true" /> : <Eye className="size-4" aria-hidden="true" />}
+                </Button>
               </div>
             </div>
           )}


### PR DESCRIPTION
## Summary
- replace the password visibility toggle text button with Eye/EyeOff icons in the login form
- add an accessible aria-label that reflects the current visibility state and keep the button compact to preserve alignment

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9139ea8dc832fb82cd29e56cf18b9