### PR TITLE
Handle staff redirects in auth flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,11 @@ La lógica para calcular el `cupoEstimado` se encuentra en el archivo `src/app/a
     *   `src/lib/validators`: Esquemas de validación Zod.
 *   `public`: Archivos estáticos (imágenes, fuentes, `robots.txt`, `sitemap.xml`).
 
+## Acceso al Backoffice
+
+*   El flujo de login acepta el parámetro opcional `redirectTo`. Si no se proporciona y el usuario tiene `profiles.is_staff = true`, será dirigido automáticamente al panel `/hq` después de autenticarse.
+*   Los enlaces internos al Backoffice deben utilizar `/login?redirectTo=/hq` para mantener el acceso directo al panel administrativo. Los accesos por Magic Link ahora apuntan a `/auth/callback`, ruta que valida la sesión y decide el destino final según el perfil del usuario.
+
 ---
 
 **Nota:** Este proyecto es un MVP funcional. Las integraciones reales con DIAN/RADIAN y otros sistemas (ERP/Facturadores) están diseñadas a nivel de interfaz (`lib/integrations/`) pero no están conectadas. El sitio está listo para producción y fácil de evolucionar.

--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { isStaffUser } from "@/lib/staff";
+
+export default function AuthCallbackPage() {
+  const router = useRouter();
+  const search = useSearchParams();
+  const code = search.get("code");
+  const redirectTo = search.get("redirectTo");
+
+  useEffect(() => {
+    const supabase = createClientComponentClient();
+    let active = true;
+
+    const processMagicLink = async () => {
+      if (!code) {
+        if (!active) return;
+        router.replace(redirectTo ?? "/login");
+        return;
+      }
+
+      const { error } = await supabase.auth.exchangeCodeForSession(code);
+      if (error) {
+        console.error("Failed to exchange OTP code", error);
+        if (!active) return;
+        router.replace("/login");
+        return;
+      }
+
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+
+      let destination = redirectTo ?? "/select-org";
+      if (!redirectTo && user?.id) {
+        const staff = await isStaffUser(supabase, user.id);
+        destination = staff ? "/hq" : "/select-org";
+      }
+
+      if (!active) return;
+      router.replace(destination);
+    };
+
+    processMagicLink();
+
+    return () => {
+      active = false;
+    };
+  }, [router, code, redirectTo]);
+
+  return (
+    <div className="py-20 sm:py-24">
+      <div className="container mx-auto max-w-md px-4 sm:px-6 lg:px-8">
+        <p className="text-lp-sec-3">Procesando acceso...</p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/hq/page.tsx
+++ b/src/app/hq/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { supabaseServer } from "@/lib/supabase-server";
 import { supabaseAdmin } from "@/lib/supabase";
 import { isBackofficeAllowed } from "@/lib/hq-auth";
@@ -6,12 +7,6 @@ import { UsersManager } from "./ui/UsersManager";
 import { DashboardMetrics } from "./ui/DashboardMetrics";
 
 export const dynamic = "force-dynamic";
-
-type CompanyRow = {
-  id: string;
-  name: string;
-  type: string;
-};
 
 export default async function HqPage() {
   const supabase = await supabaseServer();
@@ -26,7 +21,13 @@ export default async function HqPage() {
       <div className="py-10">
         <div className="container mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
           <div className="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-700">
-            No tienes permiso para ver esta página.
+            <p>
+              No tienes permiso para ver esta página. {" "}
+              <Link href="/login?redirectTo=/hq" className="underline">
+                Inicia sesión con una cuenta autorizada
+              </Link>
+              .
+            </p>
           </div>
         </div>
       </div>

--- a/src/app/select-org/page.tsx
+++ b/src/app/select-org/page.tsx
@@ -5,6 +5,7 @@ import { Suspense, useEffect, useState } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import { OrgCreator } from "./OrgCreator";
+import { isStaffUser } from "@/lib/staff";
 
 type Org = { id: string; name: string; type: string; role: string; status?: string };
 
@@ -12,33 +13,113 @@ function SelectOrgInner() {
   const [orgs, setOrgs] = useState<Org[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [allowOrgSelection, setAllowOrgSelection] = useState(false);
   const search = useSearchParams();
   const router = useRouter();
+  const code = search.get("code");
 
   useEffect(() => {
-    // Intercambio de código (si llega desde Magic Link)
-    const code = search.get("code");
-    if (code) {
-      const supabase = createClientComponentClient();
-      supabase.auth.exchangeCodeForSession(code).finally(() => router.replace("/select-org"));
-      return;
-    }
+    const supabase = createClientComponentClient();
+    let active = true;
+
+    const initialize = async () => {
+      try {
+        if (code) {
+          const { error: exchangeError } = await supabase.auth.exchangeCodeForSession(code);
+          if (exchangeError) {
+            console.error("Failed to exchange magic link code", exchangeError);
+            if (!active) return;
+            setError("No se pudo validar el enlace. Intenta nuevamente.");
+            setLoading(false);
+            return;
+          }
+
+          const {
+            data: { user },
+          } = await supabase.auth.getUser();
+
+          const destination = await resolveStaffRedirect(supabase, user?.id ?? null);
+          if (!active) return;
+          router.replace(destination);
+          return;
+        }
+
+        const {
+          data: { user },
+        } = await supabase.auth.getUser();
+
+        if (user?.id) {
+          const staff = await isStaffUser(supabase, user.id);
+          if (!active) return;
+          if (staff) {
+            router.replace("/hq");
+            return;
+          }
+        }
+
+        if (!active) return;
+        setAllowOrgSelection(true);
+      } catch (err) {
+        console.error("Failed to initialize organization selector", err);
+        if (!active) return;
+        setAllowOrgSelection(true);
+      }
+    };
+
+    const resolveStaffRedirect = async (supabaseClient: ReturnType<typeof createClientComponentClient>, userId: string | null) => {
+      if (!userId) {
+        return "/select-org";
+      }
+
+      const staff = await isStaffUser(supabaseClient, userId);
+      return staff ? "/hq" : "/select-org";
+    };
+
+    initialize();
+
+    return () => {
+      active = false;
+    };
+  }, [router, code]);
+
+  useEffect(() => {
+    if (!allowOrgSelection) return;
+
+    let active = true;
 
     const load = async () => {
       try {
         setLoading(true);
+        setError(null);
         const res = await fetch("/api/orgs");
-        if (res.status === 401) { router.replace("/login?redirectTo=/select-org"); return; }
+        if (res.status === 401) {
+          if (active) {
+            router.replace("/login?redirectTo=/select-org");
+          }
+          return;
+        }
+
         const data = await res.json();
+        if (!active) return;
         if (!res.ok) throw new Error(data.error || "Error cargando organizaciones");
         setOrgs(data.orgs ?? []);
       } catch (e: unknown) {
+        if (!active) return;
         const msg = e instanceof Error ? e.message : String(e);
         setError(msg);
-      } finally { setLoading(false); }
+      } finally {
+        if (active) {
+          setLoading(false);
+        }
+      }
     };
+
     load();
-  }, [search, router]);
+
+    return () => {
+      active = false;
+    };
+  }, [allowOrgSelection, router]);
 
   return (
     <div className="py-20 sm:py-24">
@@ -72,10 +153,12 @@ function SelectOrgInner() {
           </div>
         )}
 
-        <div className="mt-10">
-          <h2 className="font-colette text-xl font-bold text-lp-primary-1">Crear organización</h2>
-          <OrgCreator />
-        </div>
+        {allowOrgSelection && (
+          <div className="mt-10">
+            <h2 className="font-colette text-xl font-bold text-lp-primary-1">Crear organización</h2>
+            <OrgCreator />
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- update login flow to detect staff profiles after session restore or password auth and default to /hq when no redirect is provided
- send magic link emails to a new /auth/callback route that exchanges the code and routes staff users to /hq
- gate the organization selector and backoffice entry points with staff checks and document the expected redirect behavior

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2d0c2e1c0832fbfbfa0db4da69675