### PR TITLE
Relax Supabase client typing for staff helper

### DIFF
--- a/src/lib/staff.ts
+++ b/src/lib/staff.ts
@@ -1,6 +1,8 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 
-export async function isStaffUser(supabase: SupabaseClient, userId: string): Promise<boolean> {
+type AnySupabaseClient = SupabaseClient<any, any, any, any, any>;
+
+export async function isStaffUser(supabase: AnySupabaseClient, userId: string): Promise<boolean> {
   const { data } = await supabase.from('profiles').select('is_staff').eq('user_id', userId).maybeSingle();
   return !!(data && data.is_staff);
 }


### PR DESCRIPTION
## Summary
- widen the Supabase client type alias used by the staff helper to accommodate helper-provided clients
- update `isStaffUser` to accept the broader client alias

## Testing
- `npm run build` *(fails: Next.js cannot resolve @supabase/auth-helpers-nextjs / recharts in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2d8771c88832fbf5ac21d320965f5