### PR TITLE
Prevent HQ staff assignments

### DIFF
--- a/src/app/select-org/OrgCreator.tsx
+++ b/src/app/select-org/OrgCreator.tsx
@@ -8,6 +8,7 @@ export function OrgCreator() {
   const [type, setType] = useState<"CLIENT" | "INVESTOR">("CLIENT");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [isStaffBlocked, setIsStaffBlocked] = useState(false);
 
   // Sugerir nombre a partir del usuario
   useEffect(() => {
@@ -40,10 +41,13 @@ export function OrgCreator() {
       });
       if (!res.ok) {
         const data = await res.json().catch(() => ({}));
+        const isStaffError = data?.code === "HQ_STAFF";
+        setIsStaffBlocked(isStaffError);
         setError(data.error ?? `Error creando organización (HTTP ${res.status})`);
         console.error("Create org error:", data);
         return;
       }
+      setIsStaffBlocked(false);
       const data = await res.json();
       window.location.href = `/c/${data.org.id}`;
     } catch (err) {
@@ -53,6 +57,9 @@ export function OrgCreator() {
       setLoading(false);
     }
   };
+
+  const inputsDisabled = isStaffBlocked;
+  const submitDisabled = loading || isStaffBlocked;
 
   return (
     <form onSubmit={onSubmit} className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-6">
@@ -65,6 +72,7 @@ export function OrgCreator() {
           value={name}
           onChange={(e) => setName(e.target.value)}
           required
+          disabled={inputsDisabled}
         />
       </div>
       <div className="sm:col-span-2">
@@ -74,6 +82,7 @@ export function OrgCreator() {
           className="w-full rounded-md border border-lp-sec-4/60 px-3 py-2"
           value={type}
           onChange={(e) => setType(e.target.value as 'CLIENT' | 'INVESTOR')}
+          disabled={inputsDisabled}
         >
           <option value="CLIENT">CLIENT</option>
           <option value="INVESTOR">INVESTOR</option>
@@ -82,7 +91,7 @@ export function OrgCreator() {
       <div className="sm:col-span-6">
         <button
           type="submit"
-          disabled={loading}
+          disabled={submitDisabled}
           className="rounded-md bg-lp-primary-1 px-4 py-2 text-sm font-medium text-lp-primary-2 hover:opacity-90"
         >
           {loading ? "Creando..." : "Crear y entrar"}

--- a/tests/e2e/api/hq-staff.spec.ts
+++ b/tests/e2e/api/hq-staff.spec.ts
@@ -1,0 +1,172 @@
+import { test, expect } from "@playwright/test";
+
+import {
+  POST as createOrg,
+  __setOrgRouteCookies,
+  __setOrgRouteSupabaseAdmin,
+  __setOrgRouteSupabaseClientFactory,
+} from "@/app/api/orgs/route";
+import {
+  PATCH as updateMembership,
+  POST as createMembership,
+  __setMembershipsCookies,
+  __setMembershipsSupabaseAdmin,
+  __setMembershipsSupabaseClientFactory,
+} from "@/app/api/c/[orgId]/memberships/route";
+
+type MaybeSingleResult<T> = { data: T; error: { message?: string } | null };
+
+function createMaybeSingleChain<T>(result: T, error: { message?: string } | null = null) {
+  const maybeSingle = async (): Promise<MaybeSingleResult<T>> => ({ data: result, error });
+  const eq = () => ({ eq, maybeSingle });
+  const select = () => ({ eq });
+  return { select };
+}
+
+const emptyCookieStore = () => ({} as any);
+
+function createOrgSupabaseMock(profileIsStaff: boolean) {
+  return {
+    auth: {
+      async getSession() {
+        return {
+          data: {
+            session: {
+              user: {
+                id: "user-actor",
+                email: "actor@example.com",
+                user_metadata: {},
+              },
+            },
+          },
+        };
+      },
+    },
+    from(table: string) {
+      if (table === "profiles") {
+        return createMaybeSingleChain({ is_staff: profileIsStaff });
+      }
+      throw new Error(`Unexpected table access: ${table}`);
+    },
+  };
+}
+
+function createMembershipSupabaseMock() {
+  return {
+    auth: {
+      async getSession() {
+        return {
+          data: {
+            session: {
+              user: {
+                id: "user-actor",
+                email: "actor@example.com",
+                user_metadata: {},
+              },
+            },
+          },
+        };
+      },
+    },
+    from(table: string) {
+      if (table === "profiles") {
+        return createMaybeSingleChain({ is_staff: false });
+      }
+      if (table === "memberships") {
+        return createMaybeSingleChain({ role: "OWNER", status: "ACTIVE" });
+      }
+      throw new Error(`Unexpected table access: ${table}`);
+    },
+  };
+}
+
+test.afterEach(() => {
+  __setOrgRouteSupabaseClientFactory(null);
+  __setOrgRouteSupabaseAdmin(null);
+  __setOrgRouteCookies(null);
+  __setMembershipsSupabaseClientFactory(null);
+  __setMembershipsSupabaseAdmin(null);
+  __setMembershipsCookies(null);
+});
+
+test("impide que personal HQ cree organizaciones", async () => {
+  __setOrgRouteCookies(emptyCookieStore);
+  __setOrgRouteSupabaseClientFactory(() => createOrgSupabaseMock(true) as any);
+  __setOrgRouteSupabaseAdmin({
+    from() {
+      throw new Error("No se esperaba acceso a supabaseAdmin en este escenario");
+    },
+  } as any);
+
+  const request = new Request("http://localhost/api/orgs", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name: "Test", type: "CLIENT" }),
+  });
+
+  const response = await createOrg(request);
+  const body = await response.json();
+
+  expect(response.status).toBe(403);
+  expect(body).toMatchObject({ ok: false, code: "HQ_STAFF" });
+});
+
+test("impide altas de miembros para personal HQ", async () => {
+  __setMembershipsCookies(emptyCookieStore);
+  __setMembershipsSupabaseClientFactory(() => createMembershipSupabaseMock() as any);
+  __setMembershipsSupabaseAdmin({
+    from(table: string) {
+      if (table === "profiles") {
+        return createMaybeSingleChain({ is_staff: true });
+      }
+      throw new Error(`No se esperaba acceso a ${table}`);
+    },
+    auth: {},
+  } as any);
+
+  const request = new Request("http://localhost/api/c/demo/memberships", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ user_id: "hq-user", role: "ADMIN" }),
+  });
+
+  const response = await createMembership(request, { params: Promise.resolve({ orgId: "demo" }) });
+  const body = await response.json();
+
+  expect(response.status).toBe(403);
+  expect(body).toMatchObject({ ok: false, code: "HQ_STAFF" });
+});
+
+test("impide actualizaciones de miembros para personal HQ", async () => {
+  __setMembershipsCookies(emptyCookieStore);
+  __setMembershipsSupabaseClientFactory(() => createMembershipSupabaseMock() as any);
+  __setMembershipsSupabaseAdmin({
+    from(table: string) {
+      if (table === "profiles") {
+        return createMaybeSingleChain({ is_staff: true });
+      }
+      if (table === "memberships") {
+        return {
+          update() {
+            throw new Error("No se esperaba ejecutar update para personal HQ");
+          },
+        };
+      }
+      throw new Error(`No se esperaba acceso a ${table}`);
+    },
+    auth: {},
+  } as any);
+
+  const request = new Request("http://localhost/api/c/demo/memberships", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ user_id: "hq-user", status: "ACTIVE" }),
+  });
+
+  const response = await updateMembership(request, { params: Promise.resolve({ orgId: "demo" }) });
+  const body = await response.json();
+
+  expect(response.status).toBe(403);
+  expect(body).toMatchObject({ ok: false, code: "HQ_STAFF" });
+});
+


### PR DESCRIPTION
## Summary
- ensure `/api/orgs` blocks HQ staff accounts via profile checks and expose simple test hooks for overriding cookies/supabase during tests
- enforce the same HQ staff restriction across membership create/update flows and add helpers to inject mocked clients
- surface the HQ-staff denial in OrgCreator and MembersManager so the UI disables staff-only actions, and cover the scenarios with Playwright tests

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2d0d721c8832fbd1206fff2444ea8