### PR TITLE
Handle HQ user deletion fallback and surface notifications

### DIFF
--- a/src/app/hq/page.tsx
+++ b/src/app/hq/page.tsx
@@ -4,6 +4,7 @@ import { isBackofficeAllowed } from "@/lib/hq-auth";
 import { RequestsBoard } from "./ui/RequestsBoard";
 import { UsersManager } from "./ui/UsersManager";
 import { DashboardMetrics } from "./ui/DashboardMetrics";
+import { Toaster } from "@/components/ui/sonner";
 
 export const dynamic = "force-dynamic";
 
@@ -49,6 +50,7 @@ export default async function HqPage() {
           <UsersManager companies={companies ?? []} />
         </div>
       </div>
+      <Toaster position="top-right" richColors />
     </div>
   );
 }

--- a/src/app/hq/ui/UsersManager.tsx
+++ b/src/app/hq/ui/UsersManager.tsx
@@ -431,11 +431,21 @@ function ManageUserDrawer({ open, user, companies, onClose, onUpdated, onRemoved
         method: "DELETE",
         headers: { "Content-Type": "application/json" },
       });
-      const data = await response.json().catch(() => ({}));
+      const data = (await response.json().catch(() => ({}))) as {
+        deleted?: boolean;
+        message?: string;
+        error?: string;
+      };
       if (!response.ok) {
         throw new Error(data?.error || "No se pudo eliminar al usuario");
       }
-      toast.success("Usuario eliminado");
+      const successMessage =
+        typeof data?.message === "string" && data.message.trim().length
+          ? data.message
+          : data?.deleted
+            ? "Usuario eliminado"
+            : "Usuario desactivado";
+      toast.success(successMessage);
       await onRemoved();
       onClose();
     } catch (err) {


### PR DESCRIPTION
## Summary
- add hard delete fallback that performs a soft delete when Supabase reports a foreign key constraint
- centralize hard and soft delete logic for HQ users so memberships are restored/disabled consistently
- bubble API success messaging to the client and mount the Sonner toaster on the HQ page for visible feedback

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3a766e8ec832f873fcae12ab0068d