### PR TITLE
Fix HQ invite onboarding redirect

### DIFF
--- a/src/app/reset-password/page.tsx
+++ b/src/app/reset-password/page.tsx
@@ -1,11 +1,26 @@
 "use client";
 
-import { Suspense, useEffect, useState } from "react";
+import { Suspense, useEffect, useMemo, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
+
+const DEFAULT_REDIRECT_PATH = "/login";
+
+const sanitizeRedirect = (value: string | null, fallback: string) => {
+  if (!value) {
+    return fallback;
+  }
+  if (!value.startsWith("/")) {
+    return fallback;
+  }
+  if (value.startsWith("//")) {
+    return fallback;
+  }
+  return value;
+};
 
 function ResetForm() {
   const search = useSearchParams();
@@ -14,27 +29,61 @@ function ResetForm() {
   const [error, setError] = useState<string | null>(null);
   const [pw1, setPw1] = useState("");
   const [pw2, setPw2] = useState("");
+  const redirectParam = search.get("redirectTo");
+  const redirectTo = useMemo(
+    () => sanitizeRedirect(redirectParam, DEFAULT_REDIRECT_PATH),
+    [redirectParam]
+  );
 
   useEffect(() => {
     const code = search.get("code");
-    if (!code) return;
+    const supabase = createClientComponentClient();
+
     const run = async () => {
-      const supabase = createClientComponentClient();
-      try { await supabase.auth.exchangeCodeForSession(code); } catch {}
+      if (code) {
+        try {
+          await supabase.auth.exchangeCodeForSession(code);
+          return;
+        } catch (err) {
+          console.error("Failed to exchange code for session", err);
+        }
+      }
+
+      if (typeof window === "undefined") {
+        return;
+      }
+
+      const hash = window.location.hash;
+      const hasAuthFragment = hash && hash.length > 1;
+      const hasTokenQuery = Boolean(search.get("token") || search.get("type"));
+
+      if (!hasAuthFragment && !hasTokenQuery) {
+        return;
+      }
+
+      try {
+        await supabase.auth.getSessionFromUrl({ storeSession: true });
+      } catch (err) {
+        console.error("Failed to recover session from URL", err);
+      }
     };
+
     run();
   }, [search]);
 
-  const onSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!pw1 || pw1 !== pw2) { setError("Las contraseñas no coinciden"); return; }
+  const onSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!pw1 || pw1 !== pw2) {
+      setError("Las contraseñas no coinciden");
+      return;
+    }
     setLoading(true);
     setError(null);
     const supabase = createClientComponentClient();
     try {
       const { error } = await supabase.auth.updateUser({ password: pw1 });
       if (error) throw error;
-      router.replace("/login");
+      router.replace(redirectTo);
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
     } finally { setLoading(false); }
@@ -43,15 +92,25 @@ function ResetForm() {
   return (
     <div className="py-20 sm:py-24">
       <div className="container mx-auto max-w-md px-4 sm:px-6 lg:px-8">
-        <h1 className="font-colette text-3xl font-bold text-lp-primary-1">Restablecer contraseña</h1>
+        <h1 className="font-colette text-3xl font-bold text-lp-primary-1">Configura tu contraseña</h1>
         <form onSubmit={onSubmit} className="mt-6 space-y-4">
           <div>
             <Label>Nueva contraseña</Label>
-            <Input type="password" value={pw1} onChange={(e)=>setPw1(e.target.value)} required />
+            <Input
+              type="password"
+              value={pw1}
+              onChange={(event) => setPw1(event.target.value)}
+              required
+            />
           </div>
           <div>
             <Label>Confirmar contraseña</Label>
-            <Input type="password" value={pw2} onChange={(e)=>setPw2(e.target.value)} required />
+            <Input
+              type="password"
+              value={pw2}
+              onChange={(event) => setPw2(event.target.value)}
+              required
+            />
           </div>
           {error && <p className="text-sm text-red-600">{error}</p>}
           <Button type="submit" disabled={loading} className="bg-lp-primary-1 text-lp-primary-2 hover:opacity-90">{loading? 'Guardando...' : 'Guardar'}</Button>


### PR DESCRIPTION
## Summary
- ensure HQ user invites build a password setup link that routes to the reset-password flow instead of the public landing page
- let the reset-password screen sanitize custom redirect targets and handle Supabase invite fragments before sending users to the right login

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3d159ac94832faa4ae30ab2c70b06