### PR TITLE
Handle Supabase password reset session

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,14 @@ El objetivo principal del sitio es captar y convertir PYMES B2B interesadas en a
     ```
     SUPABASE_URL="https://TU_PROYECTO.supabase.co"
     SUPABASE_SERVICE_ROLE_KEY="TU_SERVICE_ROLE_KEY"
+    NEXT_PUBLIC_SUPABASE_URL="https://TU_PROYECTO.supabase.co"
+    NEXT_PUBLIC_SUPABASE_ANON_KEY="TU_ANON_KEY"
     RESEND_API_KEY="re_YOUR_RESEND_API_KEY"
     ```
     *   `SUPABASE_URL`: URL de tu proyecto Supabase.
     *   `SUPABASE_SERVICE_ROLE_KEY`: Clave de servicio de Supabase para operaciones del lado del servidor.
+    *   `NEXT_PUBLIC_SUPABASE_URL`: URL del proyecto expuesta al cliente (debe coincidir con `SUPABASE_URL`).
+    *   `NEXT_PUBLIC_SUPABASE_ANON_KEY`: Clave pública (`anon`) usada por el cliente para establecer sesiones temporales.
     *   `RESEND_API_KEY`: Clave API de Resend para el envío de correos. (Opcional para el funcionamiento básico, pero necesaria para notificaciones).
 
 4.  **Ejecutar el Servidor de Desarrollo:**
@@ -76,7 +80,7 @@ El objetivo principal del sitio es captar y convertir PYMES B2B interesadas en a
 Este proyecto está optimizado para despliegue en Vercel.
 
 1.  **Conectar Repositorio:** Conecta tu repositorio de GitHub/GitLab/Bitbucket a Vercel.
-2.  **Configurar Variables de Entorno:** En la configuración del proyecto en Vercel, añade las mismas variables de entorno (`SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `RESEND_API_KEY`) que usaste localmente.
+2.  **Configurar Variables de Entorno:** En la configuración del proyecto en Vercel, añade las mismas variables de entorno (`SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, `RESEND_API_KEY`) que usaste localmente.
 3.  **Despliegue Automático:** Cada push a la rama principal (o a una PR, si configuras los preview deploys) activará un nuevo despliegue.
 
 ## Supabase como Base de Datos
@@ -90,9 +94,11 @@ Asegúrate de definir en tu archivo `.env` las variables:
 ```
 SUPABASE_URL="https://TU_PROYECTO.supabase.co"
 SUPABASE_SERVICE_ROLE_KEY="TU_SERVICE_ROLE_KEY"
+NEXT_PUBLIC_SUPABASE_URL="https://TU_PROYECTO.supabase.co"
+NEXT_PUBLIC_SUPABASE_ANON_KEY="TU_ANON_KEY"
 ```
 
-Estas permiten que el servidor se conecte a tu instancia de Supabase.
+Las variables sin el prefijo `NEXT_PUBLIC_` se utilizan del lado del servidor, mientras que las públicas permiten que el cliente establezca sesiones válidas para operaciones como el restablecimiento de contraseñas.
 
 ### Aplicar el esquema inicial
 

--- a/src/app/auth/update-password/page.tsx
+++ b/src/app/auth/update-password/page.tsx
@@ -1,0 +1,27 @@
+import type { Metadata } from "next";
+import { ResetPasswordForm } from "@/components/auth/ResetPasswordForm";
+
+export const metadata: Metadata = {
+  title: "Configura tu contraseña | LePrêt Capital",
+  description: "Define una nueva contraseña para acceder al portal de clientes de LePrêt Capital.",
+};
+
+type SearchParams = Record<string, string | string[] | undefined>;
+
+interface UpdatePasswordPageProps {
+  searchParams?: Promise<SearchParams>;
+}
+
+export default async function UpdatePasswordPage({ searchParams }: UpdatePasswordPageProps) {
+  const params = (await searchParams) ?? {};
+  const codeParam = params.code;
+  const code = Array.isArray(codeParam) ? codeParam[0] : codeParam;
+
+  return (
+    <div className="bg-lp-primary-2 py-16 sm:py-24">
+      <div className="container mx-auto flex max-w-4xl flex-col items-center px-4 sm:px-6 lg:px-8">
+        <ResetPasswordForm code={code} />
+      </div>
+    </div>
+  );
+}

--- a/src/components/auth/ResetPasswordForm.tsx
+++ b/src/components/auth/ResetPasswordForm.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import { useEffect, useMemo, useState, type FormEvent } from "react";
+import { getSupabaseBrowserClient } from "@/lib/supabase-browser";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+
+interface ResetPasswordFormProps {
+  code?: string;
+}
+
+type Status = "idle" | "verifying" | "ready" | "submitting" | "success" | "error";
+
+export function ResetPasswordForm({ code }: ResetPasswordFormProps) {
+  const supabase = useMemo(() => getSupabaseBrowserClient(), []);
+  const [status, setStatus] = useState<Status>(code ? "verifying" : "error");
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [message, setMessage] = useState<string>("");
+
+  useEffect(() => {
+    let isMounted = true;
+
+    if (!code) {
+      setMessage(
+        "No pudimos validar el enlace de recuperación. Solicita uno nuevo desde el portal de clientes."
+      );
+      return;
+    }
+
+    const exchangeSession = async () => {
+      setStatus("verifying");
+      setMessage("Validando enlace de recuperación...");
+      const { error } = await supabase.auth.exchangeCodeForSession(code);
+
+      if (!isMounted) {
+        return;
+      }
+
+      if (error) {
+        setStatus("error");
+        setMessage(
+          "El enlace de recuperación no es válido o ya fue utilizado. Solicita uno nuevo desde el portal de clientes."
+        );
+        return;
+      }
+
+      setStatus("ready");
+      setMessage("");
+    };
+
+    void exchangeSession();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [code, supabase]);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (status !== "ready" && status !== "submitting") {
+      return;
+    }
+
+    if (!password || !confirmPassword) {
+      setMessage("Debes ingresar y confirmar tu nueva contraseña.");
+      setStatus("ready");
+      return;
+    }
+
+    if (password.length < 8) {
+      setMessage("La contraseña debe tener al menos 8 caracteres.");
+      setStatus("ready");
+      return;
+    }
+
+    if (password !== confirmPassword) {
+      setMessage("Las contraseñas no coinciden.");
+      setStatus("ready");
+      return;
+    }
+
+    setStatus("submitting");
+    setMessage("");
+
+    const { error } = await supabase.auth.updateUser({ password });
+
+    if (error) {
+      const isMissingSession = error.message === "Auth session missing";
+      const humanMessage = isMissingSession
+        ? "El enlace de recuperación expiró. Solicita uno nuevo desde el portal de clientes."
+        : error.message;
+
+      setStatus(isMissingSession ? "error" : "ready");
+      setMessage(humanMessage);
+      return;
+    }
+
+    setStatus("success");
+    setMessage("Tu contraseña fue actualizada exitosamente.");
+  };
+
+  const isInputDisabled =
+    status === "verifying" || status === "submitting" || status === "success" || status === "error";
+  const isButtonDisabled = status === "verifying" || status === "submitting" || status === "success" || status === "error";
+
+  return (
+    <div className="mx-auto w-full max-w-md rounded-2xl border border-lp-sec-4/40 bg-white p-8 shadow-soft">
+      <form className="space-y-6" onSubmit={handleSubmit}>
+        <div className="space-y-2 text-center">
+          <h1 className="font-colette text-2xl font-bold text-lp-primary-1">Configura tu contraseña</h1>
+          <p className="text-sm text-lp-sec-3">
+            Define una nueva contraseña para ingresar al portal de clientes.
+          </p>
+        </div>
+
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="password">Nueva contraseña</Label>
+            <Input
+              id="password"
+              type="password"
+              autoComplete="new-password"
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              disabled={isInputDisabled}
+              minLength={8}
+              required
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="confirm-password">Confirmar contraseña</Label>
+            <Input
+              id="confirm-password"
+              type="password"
+              autoComplete="new-password"
+              value={confirmPassword}
+              onChange={(event) => setConfirmPassword(event.target.value)}
+              disabled={isInputDisabled}
+              minLength={8}
+              required
+            />
+          </div>
+        </div>
+
+        {message && (
+          <p
+            className={`text-sm ${status === "success" ? "text-emerald-600" : "text-destructive"}`}
+            role={status === "success" ? "status" : "alert"}
+          >
+            {message}
+          </p>
+        )}
+
+        <Button
+          type="submit"
+          className="w-full bg-lp-primary-2 text-lp-primary-1 hover:opacity-90"
+          disabled={isButtonDisabled}
+        >
+          {status === "submitting" ? "Guardando..." : "Guardar"}
+        </Button>
+      </form>
+    </div>
+  );
+}

--- a/src/lib/supabase-browser.ts
+++ b/src/lib/supabase-browser.ts
@@ -1,0 +1,22 @@
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+let browserClient: SupabaseClient | undefined;
+
+export const getSupabaseBrowserClient = () => {
+  if (!browserClient) {
+    const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+    if (!url || !anonKey) {
+      throw new Error("Missing Supabase browser environment variables");
+    }
+
+    browserClient = createClient(url, anonKey, {
+      auth: {
+        persistSession: true,
+      },
+    });
+  }
+
+  return browserClient;
+};


### PR DESCRIPTION
## Summary
- add a browser Supabase client helper to establish authenticated sessions from recovery links
- create an update-password page and form that exchanges the recovery code and updates the user password with proper validation and messaging
- document the required NEXT_PUBLIC Supabase environment variables for local and production setups

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3f64863e8832fa63d1f2a65028a37