### PR TITLE
Centralize membership roles and audit access management

### DIFF
--- a/src/app/c/[orgId]/settings/ui/MembersManager.tsx
+++ b/src/app/c/[orgId]/settings/ui/MembersManager.tsx
@@ -6,25 +6,42 @@ import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import {
+  DEFAULT_MEMBER_ROLE,
+  MemberRole,
+  MemberStatus,
+  MEMBER_ROLE_VALUES,
+  MEMBER_STATUS_VALUES,
+} from "@/lib/rbac";
 
-const ROLE_OPTIONS = [
-  { value: "OWNER", label: "Owner" },
-  { value: "ADMIN", label: "Admin" },
-  { value: "OPERATOR", label: "Operador" },
-  { value: "VIEWER", label: "Consulta" },
-] as const;
+const ROLE_LABELS: Record<MemberRole, string> = {
+  OWNER: "Owner",
+  ADMIN: "Admin",
+  OPERATOR: "Operador",
+  VIEWER: "Consulta",
+};
 
-const STATUS_OPTIONS = [
-  { value: "ACTIVE", label: "Activa" },
-  { value: "INVITED", label: "Invitado" },
-  { value: "DISABLED", label: "Suspendida" },
-] as const;
+const STATUS_LABELS: Record<MemberStatus, string> = {
+  ACTIVE: "Activa",
+  INVITED: "Invitado",
+  DISABLED: "Suspendida",
+};
+
+const ROLE_OPTIONS = MEMBER_ROLE_VALUES.map((value) => ({
+  value,
+  label: ROLE_LABELS[value],
+}));
+
+const STATUS_OPTIONS = MEMBER_STATUS_VALUES.map((value) => ({
+  value,
+  label: STATUS_LABELS[value],
+}));
 
 type MemberItem = {
   user_id: string;
   full_name: string | null;
-  role: string;
-  status: string;
+  role: MemberRole;
+  status: MemberStatus;
 };
 
 type MembersResponse = {
@@ -52,7 +69,7 @@ export function MembersManager({ orgId }: MembersManagerProps) {
 
   const [adding, setAdding] = useState(false);
   const [newIdentifier, setNewIdentifier] = useState("");
-  const [newRole, setNewRole] = useState<string>("VIEWER");
+  const [newRole, setNewRole] = useState<MemberRole>(DEFAULT_MEMBER_ROLE);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -79,10 +96,12 @@ export function MembersManager({ orgId }: MembersManagerProps) {
   }, [load]);
 
   const sortedMembers = useMemo(() => {
-    return [...members].sort((a, b) => a.full_name?.localeCompare(b.full_name ?? "") || a.role.localeCompare(b.role));
+    return [...members].sort(
+      (a, b) => a.full_name?.localeCompare(b.full_name ?? "") || a.role.localeCompare(b.role)
+    );
   }, [members]);
 
-  const handleRoleChange = async (userId: string, role: string) => {
+  const handleRoleChange = async (userId: string, role: MemberRole) => {
     try {
       const res = await fetch(`/api/c/${orgId}/memberships`, {
         method: "PATCH",
@@ -101,7 +120,7 @@ export function MembersManager({ orgId }: MembersManagerProps) {
     }
   };
 
-  const handleStatusChange = async (userId: string, status: string) => {
+  const handleStatusChange = async (userId: string, status: MemberStatus) => {
     try {
       const res = await fetch(`/api/c/${orgId}/memberships`, {
         method: "PATCH",
@@ -168,7 +187,7 @@ export function MembersManager({ orgId }: MembersManagerProps) {
       }
       toast.success("Miembro agregado");
       setNewIdentifier("");
-      setNewRole("VIEWER");
+      setNewRole(DEFAULT_MEMBER_ROLE);
       await load();
     } catch (err) {
       const message = err instanceof Error ? err.message : "Error inesperado";
@@ -221,7 +240,7 @@ export function MembersManager({ orgId }: MembersManagerProps) {
                       className="w-full rounded-md border border-lp-sec-4/80 px-2 py-2 text-sm"
                       disabled={!canEdit}
                       value={member.role}
-                      onChange={(event) => handleRoleChange(member.user_id, event.target.value)}
+                      onChange={(event) => handleRoleChange(member.user_id, event.target.value as MemberRole)}
                     >
                       {ROLE_OPTIONS.map((option) => (
                         <option key={option.value} value={option.value}>
@@ -235,7 +254,7 @@ export function MembersManager({ orgId }: MembersManagerProps) {
                       className="w-full rounded-md border border-lp-sec-4/80 px-2 py-2 text-sm"
                       disabled={!canEdit}
                       value={member.status}
-                      onChange={(event) => handleStatusChange(member.user_id, event.target.value)}
+                      onChange={(event) => handleStatusChange(member.user_id, event.target.value as MemberStatus)}
                     >
                       {STATUS_OPTIONS.map((option) => (
                         <option key={option.value} value={option.value}>
@@ -284,7 +303,7 @@ export function MembersManager({ orgId }: MembersManagerProps) {
                 id="member-role"
                 className="w-full rounded-md border border-lp-sec-4/80 px-2 py-2 text-sm"
                 value={newRole}
-                onChange={(event) => setNewRole(event.target.value)}
+                onChange={(event) => setNewRole(event.target.value as MemberRole)}
               >
                 {ROLE_OPTIONS.map((option) => (
                   <option key={option.value} value={option.value}>

--- a/src/app/hq/ui/UsersManager.tsx
+++ b/src/app/hq/ui/UsersManager.tsx
@@ -6,6 +6,14 @@ import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
+import {
+  DEFAULT_MEMBER_ROLE,
+  DEFAULT_MEMBER_STATUS,
+  MemberRole,
+  MemberStatus,
+  MEMBER_ROLE_VALUES,
+  MEMBER_STATUS_VALUES,
+} from "@/lib/rbac";
 
 const TYPE_LABEL: Record<string, string> = {
   all: "Todos",
@@ -13,18 +21,28 @@ const TYPE_LABEL: Record<string, string> = {
   client: "Clientes",
 };
 
-const ROLE_OPTIONS = [
-  { value: "OWNER", label: "Owner" },
-  { value: "ADMIN", label: "Admin" },
-  { value: "OPERATOR", label: "Operator" },
-  { value: "VIEWER", label: "Viewer" },
-];
+const ROLE_LABELS: Record<MemberRole, string> = {
+  OWNER: "Owner",
+  ADMIN: "Admin",
+  OPERATOR: "Operator",
+  VIEWER: "Viewer",
+};
 
-const STATUS_OPTIONS = [
-  { value: "ACTIVE", label: "Activa" },
-  { value: "INVITED", label: "Invitado" },
-  { value: "DISABLED", label: "Suspendida" },
-];
+const STATUS_LABELS: Record<MemberStatus, string> = {
+  ACTIVE: "Activa",
+  INVITED: "Invitado",
+  DISABLED: "Suspendida",
+};
+
+const ROLE_OPTIONS = MEMBER_ROLE_VALUES.map((value) => ({
+  value,
+  label: ROLE_LABELS[value],
+}));
+
+const STATUS_OPTIONS = MEMBER_STATUS_VALUES.map((value) => ({
+  value,
+  label: STATUS_LABELS[value],
+}));
 
 type CompanyOption = {
   id: string;
@@ -35,8 +53,8 @@ type CompanyOption = {
 type MembershipInfo = {
   company_id: string;
   company_name: string | null;
-  role: string;
-  status: string;
+  role: MemberRole;
+  status: MemberStatus;
 };
 
 type UserEntry = {
@@ -320,7 +338,9 @@ function ManageUserDrawer({ open, user, companies, onClose, onUpdated, onRemoved
   const [emailDraft, setEmailDraft] = useState<string>(user?.email || "");
   const [editingEmail, setEditingEmail] = useState(false);
   const [showAdd, setShowAdd] = useState(false);
-  const [newMembership, setNewMembership] = useState<{ company_id: string; role: string; status: string } | null>(null);
+  const [newMembership, setNewMembership] = useState<{ company_id: string; role: MemberRole; status: MemberStatus } | null>(
+    null
+  );
 
   useEffect(() => {
     if (user) {
@@ -407,7 +427,10 @@ function ManageUserDrawer({ open, user, companies, onClose, onUpdated, onRemoved
     setEmailDraft(user.email || "");
   };
 
-  const handleMembershipUpdate = async (membership: MembershipInfo, next: { role?: string; status?: string }) => {
+  const handleMembershipUpdate = async (
+    membership: MembershipInfo,
+    next: { role?: MemberRole; status?: MemberStatus }
+  ) => {
     const role = next.role ?? membership.role;
     const status = next.status ?? membership.status;
     await runPatch({ companies: [{ company_id: membership.company_id, role, status }] }, `membership-${membership.company_id}`);
@@ -551,8 +574,8 @@ function ManageUserDrawer({ open, user, companies, onClose, onUpdated, onRemoved
                     setShowAdd(true);
                     setNewMembership({
                       company_id: availableCompanies[0]?.id || "",
-                      role: "VIEWER",
-                      status: "INVITED",
+                      role: DEFAULT_MEMBER_ROLE,
+                      status: DEFAULT_MEMBER_STATUS,
                     });
                   }}
                 >
@@ -596,7 +619,7 @@ function ManageUserDrawer({ open, user, companies, onClose, onUpdated, onRemoved
                           className="mt-1 w-full rounded-md border border-lp-sec-4/80 px-2 py-2 text-sm"
                           value={membership.role}
                           onChange={(event) =>
-                            handleMembershipUpdate(membership, { role: event.target.value })
+                            handleMembershipUpdate(membership, { role: event.target.value as MemberRole })
                           }
                         >
                           {ROLE_OPTIONS.map((option) => (
@@ -612,7 +635,7 @@ function ManageUserDrawer({ open, user, companies, onClose, onUpdated, onRemoved
                           className="mt-1 w-full rounded-md border border-lp-sec-4/80 px-2 py-2 text-sm"
                           value={membership.status}
                           onChange={(event) =>
-                            handleMembershipUpdate(membership, { status: event.target.value })
+                            handleMembershipUpdate(membership, { status: event.target.value as MemberStatus })
                           }
                         >
                           {STATUS_OPTIONS.map((option) => (
@@ -655,7 +678,7 @@ function ManageUserDrawer({ open, user, companies, onClose, onUpdated, onRemoved
                           value={newMembership.role}
                           onChange={(event) =>
                             setNewMembership((prev) =>
-                              prev ? { ...prev, role: event.target.value } : prev,
+                              prev ? { ...prev, role: event.target.value as MemberRole } : prev,
                             )
                           }
                         >
@@ -673,7 +696,9 @@ function ManageUserDrawer({ open, user, companies, onClose, onUpdated, onRemoved
                           value={newMembership.status}
                           onChange={(event) =>
                             setNewMembership((prev) =>
-                              prev ? { ...prev, status: event.target.value } : prev,
+                              prev
+                                ? { ...prev, status: event.target.value as MemberStatus }
+                                : prev,
                             )
                           }
                         >

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -1,11 +1,22 @@
 import { supabaseAdmin } from "@/lib/supabase";
 
+type AuditEntity = 'invoice' | 'request' | 'offer' | 'document' | 'contract' | 'membership';
+type AuditAction =
+  | 'created'
+  | 'updated'
+  | 'status_changed'
+  | 'deleted'
+  | 'signed'
+  | 'funded'
+  | 'archived'
+  | 'denied';
+
 export async function logAudit(input: {
   company_id: string;
   actor_id?: string | null;
-  entity: 'invoice' | 'request' | 'offer' | 'document' | 'contract';
+  entity: AuditEntity;
   entity_id?: string | null;
-  action: 'created' | 'updated' | 'status_changed' | 'deleted' | 'signed' | 'funded' | 'archived' | 'denied';
+  action: AuditAction;
   data?: Record<string, unknown> | null;
 }) {
   try {

--- a/src/lib/rbac.ts
+++ b/src/lib/rbac.ts
@@ -1,0 +1,103 @@
+export const MEMBER_ROLE_VALUES = ["OWNER", "ADMIN", "OPERATOR", "VIEWER"] as const;
+export type MemberRole = (typeof MEMBER_ROLE_VALUES)[number];
+
+const MEMBER_ROLE_SET = new Set<MemberRole>(MEMBER_ROLE_VALUES);
+
+const LEGACY_MEMBER_ROLE_MAP: Record<string, MemberRole> = {
+  client: "VIEWER",
+  admin: "ADMIN",
+  investor: "VIEWER",
+};
+
+export const DEFAULT_MEMBER_ROLE: MemberRole = "VIEWER";
+
+export function normalizeMemberRole(value: unknown): MemberRole | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const upper = trimmed.toUpperCase();
+  if (MEMBER_ROLE_SET.has(upper as MemberRole)) {
+    return upper as MemberRole;
+  }
+  const lower = trimmed.toLowerCase();
+  const mapped = LEGACY_MEMBER_ROLE_MAP[lower];
+  return mapped ?? null;
+}
+
+export function parseMemberRole(value: unknown, fallback?: MemberRole): MemberRole {
+  if (value === undefined || value === null || (typeof value === "string" && value.trim() === "")) {
+    if (fallback !== undefined) {
+      return fallback;
+    }
+    throw new Error("Invalid member role");
+  }
+  const normalized = normalizeMemberRole(value);
+  if (!normalized) {
+    throw new Error("Invalid member role");
+  }
+  return normalized;
+}
+
+export function requireMemberRole(value: unknown): MemberRole {
+  const normalized = normalizeMemberRole(value);
+  if (!normalized) {
+    throw new Error("Invalid member role");
+  }
+  return normalized;
+}
+
+export const MANAGER_MEMBER_ROLES = new Set<MemberRole>(["OWNER", "ADMIN"]);
+
+export function canManageMembership(role: MemberRole | null | undefined): boolean {
+  if (!role) {
+    return false;
+  }
+  return MANAGER_MEMBER_ROLES.has(role);
+}
+
+export const MEMBER_STATUS_VALUES = ["ACTIVE", "INVITED", "DISABLED"] as const;
+export type MemberStatus = (typeof MEMBER_STATUS_VALUES)[number];
+
+const MEMBER_STATUS_SET = new Set<MemberStatus>(MEMBER_STATUS_VALUES);
+
+export const DEFAULT_MEMBER_STATUS: MemberStatus = "INVITED";
+
+export function normalizeMemberStatus(value: unknown): MemberStatus | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const upper = value.trim().toUpperCase();
+  if (!upper) {
+    return null;
+  }
+  if (MEMBER_STATUS_SET.has(upper as MemberStatus)) {
+    return upper as MemberStatus;
+  }
+  return null;
+}
+
+export function parseMemberStatus(value: unknown, fallback?: MemberStatus): MemberStatus {
+  if (value === undefined || value === null || (typeof value === "string" && value.trim() === "")) {
+    if (fallback !== undefined) {
+      return fallback;
+    }
+    throw new Error("Invalid member status");
+  }
+  const normalized = normalizeMemberStatus(value);
+  if (!normalized) {
+    throw new Error("Invalid member status");
+  }
+  return normalized;
+}
+
+export function requireMemberStatus(value: unknown): MemberStatus {
+  const normalized = normalizeMemberStatus(value);
+  if (!normalized) {
+    throw new Error("Invalid member status");
+  }
+  return normalized;
+}


### PR DESCRIPTION
## Summary
- add shared RBAC helpers for membership roles and statuses with normalization helpers
- update membership APIs to use the shared utilities, return canonical data, and record audit events
- align HQ API/UI and notification helpers with the centralized roles to avoid drift

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3fbe05b34832fbf11f64244a874ce