### PR TITLE
Show organization names in client portal

### DIFF
--- a/src/app/c/[orgId]/page.tsx
+++ b/src/app/c/[orgId]/page.tsx
@@ -1,12 +1,21 @@
+import { supabaseServer } from "@/lib/supabase-server";
+import { getOrganizationDisplayName } from "@/lib/organizations";
+
 import { DashboardSummary } from "./ui/DashboardSummary";
 
 export default async function ClientDashboardPage({ params }: { params: Promise<{ orgId: string }> }) {
   const { orgId } = await params;
+  const supabase = await supabaseServer();
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+  const orgName = await getOrganizationDisplayName(supabase, orgId, session?.user?.id ?? null);
+  const displayOrg = orgName ?? orgId;
   return (
     <div className="space-y-6">
       <h1 className="font-colette text-2xl font-bold text-lp-primary-1">Resumen</h1>
       <p className="text-lp-sec-3">
-        Bienvenido al portal de clientes. Esta es una vista de resumen para la organización <span className="font-semibold">{orgId}</span>.
+        Bienvenido al portal de clientes. Esta es una vista de resumen para la organización <span className="font-semibold">{displayOrg}</span>.
       </p>
       <div className="mt-2">
         <a

--- a/src/app/c/[orgId]/settings/ui/SettingsClient.tsx
+++ b/src/app/c/[orgId]/settings/ui/SettingsClient.tsx
@@ -175,13 +175,18 @@ export function SettingsClient({ orgId }: SettingsClientProps) {
     }
   };
 
+  const displayOrgName = (() => {
+    const fromForm = form?.name?.trim() || baselineRef.current?.name?.trim() || "";
+    return fromForm || orgId;
+  })();
+
   return (
     <div className="space-y-6">
       <Toaster position="top-center" richColors />
       <div>
         <h1 className="font-colette text-2xl font-bold text-lp-primary-1">Configuracion</h1>
         <p className="text-sm text-lp-sec-3">
-          Gestiona los datos de la organizacion <span className="font-semibold text-lp-primary-1">{orgId}</span>.
+          Gestiona los datos de la organizacion <span className="font-semibold text-lp-primary-1">{displayOrgName}</span>.
         </p>
         <div className="mt-2 text-xs text-lp-sec-3">
           Rol: {isStaff ? "staff" : membershipRole ? membershipRole.toLowerCase() : "miembro"}

--- a/src/lib/organizations.ts
+++ b/src/lib/organizations.ts
@@ -1,0 +1,52 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+function extractCompanyName(source: unknown): string | null {
+  if (!source) return null;
+  if (Array.isArray(source)) {
+    for (const item of source) {
+      if (item && typeof item === "object" && "name" in item) {
+        const value = (item as { name?: unknown }).name;
+        if (typeof value === "string" && value.trim()) {
+          return value.trim();
+        }
+      }
+    }
+    return null;
+  }
+  if (typeof source === "object" && source !== null && "name" in source) {
+    const value = (source as { name?: unknown }).name;
+    if (typeof value === "string" && value.trim()) {
+      return value.trim();
+    }
+  }
+  return null;
+}
+
+export async function getOrganizationDisplayName(
+  supabase: SupabaseClient,
+  orgId: string,
+  userId?: string | null,
+): Promise<string | null> {
+  const memberUserId = typeof userId === "string" && userId.length ? userId : null;
+
+  if (memberUserId) {
+    const { data: membership } = await supabase
+      .from("memberships")
+      .select("companies(name)")
+      .eq("company_id", orgId)
+      .eq("user_id", memberUserId)
+      .maybeSingle();
+
+    const membershipName = extractCompanyName(membership?.companies);
+    if (membershipName) return membershipName;
+  }
+
+  const { data: company } = await supabase
+    .from("companies")
+    .select("name")
+    .eq("id", orgId)
+    .maybeSingle();
+
+  const directName = typeof company?.name === "string" && company.name.trim() ? company.name.trim() : null;
+  return directName;
+}


### PR DESCRIPTION
## Summary
- reuse a shared helper to resolve an organization's display name in the client portal
- render the human-friendly organization name on the dashboard intro and settings header
- fall back to the organization name when present instead of raw ids across the client pages

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d43777c050832fabad3ec4c0aa5707