### PR TITLE
Skip native validation in invoice form

### DIFF
--- a/src/app/c/[orgId]/invoices/ui/InvoicesClient.tsx
+++ b/src/app/c/[orgId]/invoices/ui/InvoicesClient.tsx
@@ -542,7 +542,7 @@ export function InvoicesClient({ orgId }: { orgId: string }) {
               <CardDescription>Completa los datos obligatorios. Guardamos tu progreso automáticamente al enviar.</CardDescription>
             </CardHeader>
             <CardContent>
-              <form onSubmit={onCreate} className="grid grid-cols-1 gap-4 sm:grid-cols-6">
+              <form noValidate onSubmit={onCreate} className="grid grid-cols-1 gap-4 sm:grid-cols-6">
                 <div className="sm:col-span-2 space-y-1">
                   <Label htmlFor="invoice-amount">
                     Monto (COP)


### PR DESCRIPTION
## Summary
- disable the browser's built-in validation for the quick invoice creation form so our custom validation logic can run without locale issues

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d44a48b758832f8c9e225befe0516f