### PR TITLE
Limit invoice reuse and capture payer metadata

### DIFF
--- a/src/app/api/c/[orgId]/invoices/by-ids/route.ts
+++ b/src/app/api/c/[orgId]/invoices/by-ids/route.ts
@@ -19,7 +19,7 @@ export async function POST(
 
     const { data, error } = await supabase
       .from('invoices')
-      .select('id, amount, issue_date, due_date, status, file_path')
+      .select('id, amount, issue_date, due_date, status, file_path, payer, forecast_payment_date')
       .in('id', ids)
       .eq('company_id', orgId);
     if (error) return NextResponse.json({ ok: false, error: error.message }, { status: 500 });

--- a/src/app/api/c/[orgId]/invoices/helpers.ts
+++ b/src/app/api/c/[orgId]/invoices/helpers.ts
@@ -1,0 +1,53 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+export async function getUsedInvoiceIds(
+  supabase: SupabaseClient,
+  orgId: string,
+): Promise<Set<string>> {
+  const used = new Set<string>();
+
+  const { data: direct } = await supabase
+    .from("funding_requests")
+    .select("invoice_id, id")
+    .eq("company_id", orgId)
+    .not("invoice_id", "is", null);
+
+  direct?.forEach((row) => {
+    const invoiceId = (row as { invoice_id?: string | null }).invoice_id;
+    if (invoiceId) used.add(invoiceId);
+  });
+
+  const { data: relations } = await supabase
+    .from("funding_request_invoices")
+    .select("invoice_id, request_id");
+
+  const requestIds = Array.from(
+    new Set(
+      (relations || [])
+        .map((row) => (row as { request_id?: string | null }).request_id)
+        .filter((id): id is string => typeof id === "string" && id.length > 0),
+    ),
+  );
+
+  if (requestIds.length > 0) {
+    const { data: reqs } = await supabase
+      .from("funding_requests")
+      .select("id")
+      .eq("company_id", orgId)
+      .in("id", requestIds);
+
+    const allowed = new Set((reqs || []).map((row) => (row as { id: string }).id));
+
+    (relations || []).forEach((row) => {
+      const invoiceId = (row as { invoice_id?: string | null }).invoice_id;
+      const requestId = (row as { request_id?: string | null }).request_id;
+      if (invoiceId && requestId && allowed.has(requestId)) used.add(invoiceId);
+    });
+  }
+
+  return used;
+}
+
+export function formatIdsForNotIn(ids: string[]): string {
+  return `(${ids.map((id) => `"${id}"`).join(",")})`;
+}


### PR DESCRIPTION
## Summary
- ensure invoice listings, exports, and KPI metrics ignore documents already linked to funding requests by sharing a helper across API routes
- add Pagador and Forecast Pago inputs when registering invoices, surface the new columns in the table, and persist them through Supabase writes/exports
- prevent generating funding requests with invoices that were already used and show a friendly error both in the invoice list and the request wizard

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4e0398778832f99182ef4ca1c43d0