### PR TITLE
Ensure LP monogram remains visible in navbar

### DIFF
--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -2,8 +2,15 @@ import Image from 'next/image';
 
 export function Logo() {
   return (
-    <div className="flex h-8 w-8 items-center justify-center">
-      <Image src="/LPsinFondo.png" alt="LePrêt Capital Logo" width={32} height={32} />
+    <div className="flex h-10 w-10 items-center justify-center rounded-full bg-lp-primary-2 shadow-sm">
+      <Image
+        src="/LPsinFondo.png"
+        alt="Monograma LP de LePrêt Capital"
+        width={32}
+        height={32}
+        className="h-7 w-7 object-contain"
+        priority
+      />
     </div>
   );
 }

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -55,14 +55,16 @@ export function Navbar() {
   return (
     <>
       <header className="sticky top-0 z-50 w-full border-b border-lp-sec-4/50 bg-lp-primary-1 backdrop-blur-sm">
-        <div className="container mx-auto flex h-16 max-w-7xl items-center justify-start px-4 sm:px-6 lg:px-8">
-          <Link href="/" className="flex items-center space-x-2" onClick={() => setIsMenuOpen(false)}>
-            <Logo />
-            <Image src="/LePretSinFondo.png" alt="LePrêt Capital" width={281} height={281} className="mt-[-15px]" />
-          </Link>
-          
+        <div className="container mx-auto flex h-16 max-w-7xl items-center px-4 sm:px-6 lg:px-8">
+          <div className="flex flex-1 items-center">
+            <Link href="/" className="flex items-center space-x-2" onClick={() => setIsMenuOpen(false)}>
+              <Logo />
+              <Image src="/LePretSinFondo.png" alt="LePrêt Capital" width={281} height={281} className="mt-[-15px]" />
+            </Link>
+          </div>
+
           {/* Desktop Navigation */}
-          <nav className="hidden items-center space-x-4 md:flex ml-36">
+          <nav className="hidden items-center justify-center gap-6 px-4 md:flex">
             {navLinks.map((link) => {
               const isActive = pathname === link.href || pathname === link.href.split('?')[0];
               return (
@@ -77,7 +79,7 @@ export function Navbar() {
             })}
           </nav>
 
-          <div className="flex items-center space-x-4 ml-auto">
+          <div className="flex flex-1 items-center justify-end gap-4 md:pl-4">
             <div className="hidden md:block">
               <Button
                 asChild


### PR DESCRIPTION
## Summary
- refresh the Logo component so the LP monogram sits on a light circular background and stays visible against the dark navbar
- load the LP asset with object-contain sizing and priority to avoid clipping or delays

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68da3e7a5430832f8e996b465c8fd08d