### PR TITLE
Add company onboarding wizard and enforce KYC flow

### DIFF
--- a/src/app/(auth)/registro/_components/OnboardingShell.tsx
+++ b/src/app/(auth)/registro/_components/OnboardingShell.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { useMemo } from "react";
+import Link from "next/link";
+
+import { Stepper } from "@/components/ui/stepper";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+
+import { useOnboarding } from "./useOnboarding";
+
+const STEPS = [
+  { title: "Datos de la empresa", description: "Información legal y de contacto" },
+  { title: "Beneficiarios", description: "Personas con participación significativa" },
+  { title: "Documentos", description: "Adjunta la documentación requerida" },
+] as const;
+
+export type OnboardingShellProps = {
+  companyId: string;
+  currentStep: number;
+  title: string;
+  description?: string;
+  children: (args: ReturnType<typeof useOnboarding>) => ReactNode;
+};
+
+export function OnboardingShell({ companyId, currentStep, title, description, children }: OnboardingShellProps) {
+  const onboarding = useOnboarding(companyId);
+  const { data, loading, error } = onboarding;
+  const companyName = data.company?.legalName || data.company?.name || "Tu empresa";
+
+  const stepper = useMemo(
+    () => <Stepper steps={STEPS} current={Math.min(Math.max(currentStep, 0), STEPS.length - 1)} className="w-full" />,
+    [currentStep],
+  );
+
+  return (
+    <div className="space-y-8">
+      <header className="space-y-2">
+        <p className="text-sm uppercase tracking-wider text-lp-sec-3">Registro</p>
+        <h1 className="font-colette text-3xl font-bold text-lp-primary-1">{title}</h1>
+        <p className="text-lp-sec-3">{description ?? `Organización: ${companyName}`}</p>
+      </header>
+
+      <div className="grid gap-8 lg:grid-cols-[280px_1fr]">
+        <aside className="space-y-4">
+          <div className="rounded-xl border border-lp-sec-4/40 bg-white p-4 shadow-sm">
+            <h2 className="text-sm font-semibold text-lp-primary-1">Progreso</h2>
+            <div className="mt-4 space-y-3 text-sm text-lp-sec-3">{stepper}</div>
+          </div>
+          <div className="rounded-xl border border-lp-sec-4/40 bg-lp-primary-1/5 p-4 text-sm text-lp-sec-2">
+            <p className="font-medium text-lp-primary-1">¿Necesitas ayuda?</p>
+            <p className="mt-2">Escríbenos a <a href="mailto:soporte@lepret.com" className="underline">soporte@lepret.com</a>.</p>
+            <p className="mt-2">También puedes regresar al selector de organizaciones si lo necesitas.</p>
+            <Button asChild variant="outline" className="mt-4 w-full">
+              <Link href="/select-org">Volver a organizaciones</Link>
+            </Button>
+          </div>
+        </aside>
+
+        <section className="space-y-6">
+          {error && !loading ? (
+            <Alert variant="destructive">
+              <AlertTitle>Error cargando información</AlertTitle>
+              <AlertDescription>
+                {error === "Forbidden"
+                  ? "No tienes permisos para editar esta empresa."
+                  : "No pudimos cargar la información. Intenta nuevamente."}
+              </AlertDescription>
+            </Alert>
+          ) : null}
+
+          {loading ? (
+            <div className="space-y-4">
+              <Skeleton className="h-12 w-full" />
+              <Skeleton className="h-12 w-full" />
+              <Skeleton className="h-40 w-full" />
+            </div>
+          ) : (
+            children(onboarding)
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}
+
+export { STEPS as ONBOARDING_STEPS };

--- a/src/app/(auth)/registro/_components/useOnboarding.ts
+++ b/src/app/(auth)/registro/_components/useOnboarding.ts
@@ -1,0 +1,170 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+type RawOwner = {
+  id?: string;
+  full_name?: string | null;
+  document_type?: string | null;
+  document_number?: string | null;
+  email?: string | null;
+  ownership_percentage?: number | null;
+};
+
+export type OnboardingOwner = {
+  fullName: string;
+  documentType: string;
+  documentNumber: string;
+  email: string;
+  ownershipPercentage: number | null;
+};
+
+export type OnboardingAddress = {
+  type: string;
+  line1: string;
+  line2: string;
+  city: string;
+  state: string;
+  postalCode: string;
+  country: string;
+};
+
+export type OnboardingCompany = {
+  id: string;
+  name: string;
+  legalName: string;
+  taxId: string;
+  contactEmail: string;
+  contactPhone: string;
+  billingEmail: string;
+  bankAccount: string;
+  kycStatus: string | null;
+  kycSubmittedAt?: string | null;
+  kycApprovedAt?: string | null;
+};
+
+export type OnboardingDocument = {
+  name: string;
+  path: string;
+  createdAt?: string;
+  updatedAt?: string;
+  size?: number;
+};
+
+export type OnboardingState = {
+  company: OnboardingCompany | null;
+  address: OnboardingAddress | null;
+  owners: OnboardingOwner[];
+  documents: OnboardingDocument[];
+  role: string | null;
+};
+
+const EMPTY_STATE: OnboardingState = {
+  company: null,
+  address: null,
+  owners: [],
+  documents: [],
+  role: null,
+};
+
+function mapOwner(row: RawOwner): OnboardingOwner {
+  return {
+    fullName: row.full_name ?? "",
+    documentType: row.document_type ?? "",
+    documentNumber: row.document_number ?? "",
+    email: row.email ?? "",
+    ownershipPercentage:
+      typeof row.ownership_percentage === "number" ? row.ownership_percentage : row.ownership_percentage ?? null,
+  };
+}
+
+function mapAddress(row: Record<string, unknown> | null | undefined): OnboardingAddress | null {
+  if (!row) return null;
+  const get = (key: string) => {
+    const value = row[key];
+    return typeof value === "string" ? value : "";
+  };
+  return {
+    type: get("type"),
+    line1: get("line1"),
+    line2: get("line2"),
+    city: get("city"),
+    state: get("state"),
+    postalCode: get("postal_code"),
+    country: get("country"),
+  };
+}
+
+function mapCompany(row: Record<string, unknown> | null | undefined): OnboardingCompany | null {
+  if (!row || typeof row !== "object") return null;
+  const str = (key: string) => {
+    const value = row[key as keyof typeof row];
+    return typeof value === "string" ? value : "";
+  };
+  return {
+    id: str("id"),
+    name: str("name"),
+    legalName: str("legal_name"),
+    taxId: str("tax_id"),
+    contactEmail: str("contact_email"),
+    contactPhone: str("contact_phone"),
+    billingEmail: str("billing_email"),
+    bankAccount: str("bank_account"),
+    kycStatus: typeof row["kyc_status"] === "string" ? String(row["kyc_status"]) : null,
+    kycSubmittedAt: typeof row["kyc_submitted_at"] === "string" ? String(row["kyc_submitted_at"]) : null,
+    kycApprovedAt: typeof row["kyc_approved_at"] === "string" ? String(row["kyc_approved_at"]) : null,
+  };
+}
+
+export function useOnboarding(companyId: string | null | undefined) {
+  const [state, setState] = useState<OnboardingState>(EMPTY_STATE);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchData = useCallback(async () => {
+    if (!companyId) {
+      setState(EMPTY_STATE);
+      setError("missing-company");
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetch(`/api/onboarding/${companyId}`, { cache: "no-store" });
+      if (!response.ok) {
+        const payload = await response.json().catch(() => ({}));
+        const message = typeof payload?.error === "string" ? payload.error : "unknown";
+        throw new Error(message);
+      }
+      const payload = await response.json();
+      const owners = Array.isArray(payload.owners) ? payload.owners.map(mapOwner) : [];
+      const documents = Array.isArray(payload.documents) ? payload.documents : [];
+      setState({
+        company: mapCompany(payload.company),
+        address: mapAddress(payload.address),
+        owners,
+        documents,
+        role: typeof payload.role === "string" ? payload.role : null,
+      });
+    } catch (err) {
+      console.error("useOnboarding fetch error", err);
+      setState(EMPTY_STATE);
+      setError(err instanceof Error ? err.message : "unknown");
+    } finally {
+      setLoading(false);
+    }
+  }, [companyId]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  const memoState = useMemo(() => state, [state]);
+
+  return { data: memoState, loading, error, refresh: fetchData, setState } as const;
+}
+
+export type UseOnboardingReturn = ReturnType<typeof useOnboarding>;

--- a/src/app/(auth)/registro/beneficiarios/BeneficiariesForm.tsx
+++ b/src/app/(auth)/registro/beneficiarios/BeneficiariesForm.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useFieldArray, useForm } from "react-hook-form";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+
+import type { OnboardingOwner, UseOnboardingReturn } from "../_components/useOnboarding";
+
+type OwnerFormValues = {
+  fullName: string;
+  documentType: string;
+  documentNumber: string;
+  email: string;
+  ownershipPercentage: string;
+};
+
+type BeneficiariesFormValues = {
+  owners: OwnerFormValues[];
+};
+
+type BeneficiariesFormProps = {
+  companyId: string;
+  onboarding: UseOnboardingReturn;
+};
+
+function getDefaultOwners(owners: OnboardingOwner[]): OwnerFormValues[] {
+  if (!owners.length) {
+    return [
+      { fullName: "", documentType: "CC", documentNumber: "", email: "", ownershipPercentage: "" },
+    ];
+  }
+  return owners.map((owner) => ({
+    fullName: owner.fullName,
+    documentType: owner.documentType || "CC",
+    documentNumber: owner.documentNumber,
+    email: owner.email,
+    ownershipPercentage: owner.ownershipPercentage != null ? String(owner.ownershipPercentage) : "",
+  }));
+}
+
+export function BeneficiariesForm({ companyId, onboarding }: BeneficiariesFormProps) {
+  const router = useRouter();
+  const defaults = useMemo(() => getDefaultOwners(onboarding.data.owners), [onboarding.data.owners]);
+  const form = useForm<BeneficiariesFormValues>({ defaultValues: { owners: defaults } });
+  const { fields, append, remove } = useFieldArray({ control: form.control, name: "owners" });
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    form.reset({ owners: defaults });
+  }, [defaults, form]);
+
+  const handleAddOwner = () => {
+    append({ fullName: "", documentType: "CC", documentNumber: "", email: "", ownershipPercentage: "" });
+  };
+
+  const handleSubmit = form.handleSubmit(async (values) => {
+    setSaving(true);
+    setError(null);
+    try {
+      const owners = values.owners.filter((owner) => owner.fullName.trim() && owner.documentNumber.trim());
+      const response = await fetch(`/api/onboarding/${companyId}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          section: "owners",
+          owners: owners.map((owner) => ({
+            fullName: owner.fullName,
+            documentType: owner.documentType,
+            documentNumber: owner.documentNumber,
+            email: owner.email,
+            ownershipPercentage: owner.ownershipPercentage ? Number(owner.ownershipPercentage) : null,
+          })),
+        }),
+      });
+      if (!response.ok) {
+        const payload = await response.json().catch(() => ({}));
+        const message = typeof payload?.error === "string" ? payload.error : "Error guardando beneficiarios";
+        throw new Error(message);
+      }
+      toast.success("Beneficiarios guardados");
+      await onboarding.refresh();
+      router.push(`/registro/documentos?orgId=${encodeURIComponent(companyId)}`);
+    } catch (err) {
+      console.error("beneficiaries form error", err);
+      setError(err instanceof Error ? err.message : "Error inesperado");
+      toast.error("No pudimos guardar la información");
+    } finally {
+      setSaving(false);
+    }
+  });
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6">
+      <div className="space-y-4">
+        {fields.map((field, index) => (
+          <div key={field.id} className="rounded-xl border border-lp-sec-4/40 bg-white p-6 shadow-sm">
+            <div className="flex flex-col gap-6 md:grid md:grid-cols-2">
+              <div>
+                <Label htmlFor={`owners-${index}-fullName`}>Nombre completo</Label>
+                <Input id={`owners-${index}-fullName`} {...form.register(`owners.${index}.fullName` as const)} />
+              </div>
+              <div>
+                <Label htmlFor={`owners-${index}-documentType`}>Tipo de documento</Label>
+                <Input id={`owners-${index}-documentType`} {...form.register(`owners.${index}.documentType` as const)} />
+              </div>
+              <div>
+                <Label htmlFor={`owners-${index}-documentNumber`}>Número de documento</Label>
+                <Input id={`owners-${index}-documentNumber`} {...form.register(`owners.${index}.documentNumber` as const)} />
+              </div>
+              <div>
+                <Label htmlFor={`owners-${index}-email`}>Email</Label>
+                <Input id={`owners-${index}-email`} type="email" {...form.register(`owners.${index}.email` as const)} />
+              </div>
+              <div>
+                <Label htmlFor={`owners-${index}-ownershipPercentage`}>Porcentaje de participación</Label>
+                <Input
+                  id={`owners-${index}-ownershipPercentage`}
+                  type="number"
+                  step="0.01"
+                  min="0"
+                  max="100"
+                  {...form.register(`owners.${index}.ownershipPercentage` as const)}
+                />
+              </div>
+            </div>
+            {fields.length > 1 ? (
+              <div className="mt-4 text-right">
+                <Button type="button" variant="ghost" onClick={() => remove(index)}>
+                  Eliminar
+                </Button>
+              </div>
+            ) : null}
+          </div>
+        ))}
+      </div>
+
+      <Button type="button" variant="outline" onClick={handleAddOwner}>
+        Añadir beneficiario
+      </Button>
+
+      {error ? (
+        <Alert variant="destructive">
+          <AlertTitle>Error</AlertTitle>
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      ) : null}
+
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <Button type="button" variant="ghost" onClick={() => router.push(`/registro/datos-empresa?orgId=${encodeURIComponent(companyId)}`)} className="w-full sm:w-auto">
+          Volver
+        </Button>
+        <Button type="submit" disabled={saving} className="w-full sm:w-auto">
+          {saving ? "Guardando..." : "Guardar y continuar"}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/app/(auth)/registro/beneficiarios/page.tsx
+++ b/src/app/(auth)/registro/beneficiarios/page.tsx
@@ -1,0 +1,25 @@
+import { redirect } from "next/navigation";
+
+import { OnboardingShell } from "../_components/OnboardingShell";
+import { BeneficiariesForm } from "./BeneficiariesForm";
+
+type SearchParams = Record<string, string | string[] | undefined>;
+
+type BeneficiariosPageProps = {
+  searchParams?: Promise<SearchParams>;
+};
+
+export default async function BeneficiariosPage({ searchParams }: BeneficiariosPageProps) {
+  const params = (await searchParams) ?? {};
+  const orgParam = params.orgId;
+  const orgId = Array.isArray(orgParam) ? orgParam[0] : orgParam;
+  if (!orgId) {
+    redirect("/select-org?reason=missing-org");
+  }
+
+  return (
+    <OnboardingShell companyId={orgId} currentStep={1} title="Beneficiarios finales">
+      {(onboarding) => <BeneficiariesForm companyId={orgId} onboarding={onboarding} />}
+    </OnboardingShell>
+  );
+}

--- a/src/app/(auth)/registro/datos-empresa/CompanyForm.tsx
+++ b/src/app/(auth)/registro/datos-empresa/CompanyForm.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useForm } from "react-hook-form";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import type { OnboardingState, UseOnboardingReturn } from "../_components/useOnboarding";
+
+type CompanyFormValues = {
+  legalName: string;
+  taxId: string;
+  contactEmail: string;
+  contactPhone: string;
+  billingEmail: string;
+  bankAccount: string;
+  addressLine1: string;
+  addressLine2: string;
+  city: string;
+  state: string;
+  postalCode: string;
+  country: string;
+};
+
+type CompanyFormProps = {
+  companyId: string;
+  onboarding: UseOnboardingReturn;
+};
+
+function getDefaults(state: OnboardingState): CompanyFormValues {
+  return {
+    legalName: state.company?.legalName ?? "",
+    taxId: state.company?.taxId ?? "",
+    contactEmail: state.company?.contactEmail ?? "",
+    contactPhone: state.company?.contactPhone ?? "",
+    billingEmail: state.company?.billingEmail ?? "",
+    bankAccount: state.company?.bankAccount ?? "",
+    addressLine1: state.address?.line1 ?? "",
+    addressLine2: state.address?.line2 ?? "",
+    city: state.address?.city ?? "",
+    state: state.address?.state ?? "",
+    postalCode: state.address?.postalCode ?? "",
+    country: state.address?.country ?? "Colombia",
+  };
+}
+
+export function CompanyForm({ companyId, onboarding }: CompanyFormProps) {
+  const router = useRouter();
+  const { data, refresh } = onboarding;
+  const defaults = useMemo(() => getDefaults(data), [data]);
+  const form = useForm<CompanyFormValues>({ defaultValues: defaults });
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    form.reset(defaults);
+  }, [defaults, form]);
+
+  const handleSubmit = form.handleSubmit(async (values) => {
+    setSaving(true);
+    setError(null);
+    try {
+      const response = await fetch(`/api/onboarding/${companyId}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          section: "company",
+          company: {
+            legalName: values.legalName,
+            taxId: values.taxId,
+            contactEmail: values.contactEmail,
+            contactPhone: values.contactPhone,
+            billingEmail: values.billingEmail,
+            bankAccount: values.bankAccount,
+            address: {
+              type: "LEGAL",
+              line1: values.addressLine1,
+              line2: values.addressLine2,
+              city: values.city,
+              state: values.state,
+              postalCode: values.postalCode,
+              country: values.country,
+            },
+          },
+        }),
+      });
+      if (!response.ok) {
+        const payload = await response.json().catch(() => ({}));
+        const message = typeof payload?.error === "string" ? payload.error : "Error guardando datos";
+        throw new Error(message);
+      }
+      toast.success("Datos de la empresa guardados");
+      await refresh();
+      router.push(`/registro/beneficiarios?orgId=${encodeURIComponent(companyId)}`);
+    } catch (err) {
+      console.error("company form error", err);
+      setError(err instanceof Error ? err.message : "Error inesperado");
+      toast.error("No pudimos guardar la información");
+    } finally {
+      setSaving(false);
+    }
+  });
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6">
+      <div className="rounded-xl border border-lp-sec-4/40 bg-white p-6 shadow-sm">
+        <div className="grid gap-6 md:grid-cols-2">
+          <div>
+            <Label htmlFor="legalName">Razón social</Label>
+            <Input id="legalName" autoComplete="organization" {...form.register("legalName")} />
+          </div>
+          <div>
+            <Label htmlFor="taxId">NIT</Label>
+            <Input id="taxId" autoComplete="off" {...form.register("taxId")} />
+          </div>
+          <div>
+            <Label htmlFor="contactEmail">Email de contacto</Label>
+            <Input id="contactEmail" type="email" autoComplete="email" {...form.register("contactEmail")} />
+          </div>
+          <div>
+            <Label htmlFor="contactPhone">Teléfono de contacto</Label>
+            <Input id="contactPhone" autoComplete="tel" {...form.register("contactPhone")} />
+          </div>
+          <div>
+            <Label htmlFor="billingEmail">Email de facturación</Label>
+            <Input id="billingEmail" type="email" autoComplete="email" {...form.register("billingEmail")} />
+          </div>
+          <div>
+            <Label htmlFor="bankAccount">Cuenta bancaria</Label>
+            <Input id="bankAccount" autoComplete="off" placeholder="Banco - Número de cuenta" {...form.register("bankAccount")} />
+          </div>
+        </div>
+      </div>
+
+      <div className="rounded-xl border border-lp-sec-4/40 bg-white p-6 shadow-sm">
+        <h2 className="text-lg font-semibold text-lp-primary-1">Dirección legal</h2>
+        <div className="mt-4 grid gap-6 md:grid-cols-2">
+          <div className="md:col-span-2">
+            <Label htmlFor="addressLine1">Dirección</Label>
+            <Input id="addressLine1" autoComplete="address-line1" {...form.register("addressLine1")} />
+          </div>
+          <div className="md:col-span-2">
+            <Label htmlFor="addressLine2">Complemento</Label>
+            <Input id="addressLine2" autoComplete="address-line2" {...form.register("addressLine2")} />
+          </div>
+          <div>
+            <Label htmlFor="city">Ciudad</Label>
+            <Input id="city" autoComplete="address-level2" {...form.register("city")} />
+          </div>
+          <div>
+            <Label htmlFor="state">Departamento</Label>
+            <Input id="state" autoComplete="address-level1" {...form.register("state")} />
+          </div>
+          <div>
+            <Label htmlFor="postalCode">Código postal</Label>
+            <Input id="postalCode" autoComplete="postal-code" {...form.register("postalCode")} />
+          </div>
+          <div>
+            <Label htmlFor="country">País</Label>
+            <Input id="country" autoComplete="country-name" {...form.register("country")} />
+          </div>
+        </div>
+      </div>
+
+      {error ? <p className="text-sm text-red-600">{error}</p> : null}
+
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <Button type="submit" disabled={saving} className="w-full sm:w-auto">
+          {saving ? "Guardando..." : "Guardar y continuar"}
+        </Button>
+        <Button type="button" variant="ghost" onClick={() => router.push("/select-org")} className="w-full sm:w-auto">
+          Cancelar
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/app/(auth)/registro/datos-empresa/page.tsx
+++ b/src/app/(auth)/registro/datos-empresa/page.tsx
@@ -1,0 +1,25 @@
+import { redirect } from "next/navigation";
+
+import { OnboardingShell } from "../_components/OnboardingShell";
+import { CompanyForm } from "./CompanyForm";
+
+type SearchParams = Record<string, string | string[] | undefined>;
+
+type DatosEmpresaPageProps = {
+  searchParams?: Promise<SearchParams>;
+};
+
+export default async function DatosEmpresaPage({ searchParams }: DatosEmpresaPageProps) {
+  const params = (await searchParams) ?? {};
+  const orgParam = params.orgId;
+  const orgId = Array.isArray(orgParam) ? orgParam[0] : orgParam;
+  if (!orgId) {
+    redirect("/select-org?reason=missing-org");
+  }
+
+  return (
+    <OnboardingShell companyId={orgId} currentStep={0} title="Datos de la empresa">
+      {(onboarding) => <CompanyForm companyId={orgId} onboarding={onboarding} />}
+    </OnboardingShell>
+  );
+}

--- a/src/app/(auth)/registro/documentos/DocumentsStep.tsx
+++ b/src/app/(auth)/registro/documentos/DocumentsStep.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import type { UseOnboardingReturn } from "../_components/useOnboarding";
+import { normalizeKycStatus } from "@/lib/organizations";
+
+type DocumentsStepProps = {
+  companyId: string;
+  onboarding: UseOnboardingReturn;
+};
+
+type UploadState = Record<string, boolean>;
+
+type RequiredDoc = {
+  key: string;
+  label: string;
+  description: string;
+};
+
+const REQUIRED_DOCS: RequiredDoc[] = [
+  { key: "rut", label: "RUT actualizado", description: "Formato PDF o imagen del Registro Único Tributario." },
+  { key: "representante", label: "Documento del representante legal", description: "Cédula o pasaporte vigente del representante." },
+  { key: "estatutos", label: "Documentos societarios", description: "Acta o certificación de existencia y representación legal." },
+];
+
+function formatBytes(bytes?: number): string {
+  if (!bytes) return "";
+  const units = ["B", "KB", "MB", "GB"];
+  let value = bytes;
+  let unitIndex = 0;
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex += 1;
+  }
+  return `${value.toFixed(1)} ${units[unitIndex]}`;
+}
+
+export function DocumentsStep({ companyId, onboarding }: DocumentsStepProps) {
+  const router = useRouter();
+  const [uploading, setUploading] = useState<UploadState>({});
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const documents = onboarding.data.documents;
+  const kycStatus = onboarding.data.company?.kycStatus ?? null;
+  const normalizedStatus = normalizeKycStatus(kycStatus);
+
+  const handleUpload = async (docKey: string, fileList: FileList | null) => {
+    if (!fileList || !fileList.length) return;
+    const file = fileList[0];
+    setUploading((prev) => ({ ...prev, [docKey]: true }));
+    setError(null);
+    try {
+      const formData = new FormData();
+      formData.append("type", docKey);
+      formData.append("file", file);
+      const response = await fetch(`/api/onboarding/${companyId}/documents`, {
+        method: "POST",
+        body: formData,
+      });
+      if (!response.ok) {
+        const payload = await response.json().catch(() => ({}));
+        const message = typeof payload?.error === "string" ? payload.error : "Error subiendo archivo";
+        throw new Error(message);
+      }
+      toast.success("Documento cargado correctamente");
+      await onboarding.refresh();
+    } catch (err) {
+      console.error("document upload error", err);
+      setError(err instanceof Error ? err.message : "Error inesperado");
+      toast.error("No pudimos subir el documento");
+    } finally {
+      setUploading((prev) => ({ ...prev, [docKey]: false }));
+    }
+  };
+
+  const handleDelete = async (path: string) => {
+    setError(null);
+    try {
+      const response = await fetch(`/api/onboarding/${companyId}/documents`, {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ path }),
+      });
+      if (!response.ok) {
+        const payload = await response.json().catch(() => ({}));
+        const message = typeof payload?.error === "string" ? payload.error : "Error eliminando archivo";
+        throw new Error(message);
+      }
+      toast.success("Documento eliminado");
+      await onboarding.refresh();
+    } catch (err) {
+      console.error("document delete error", err);
+      setError(err instanceof Error ? err.message : "Error inesperado");
+      toast.error("No pudimos eliminar el documento");
+    }
+  };
+
+  const handleSubmit = async () => {
+    setSubmitting(true);
+    setError(null);
+    try {
+      const response = await fetch(`/api/onboarding/${companyId}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ section: "status", status: "SUBMITTED" }),
+      });
+      if (!response.ok) {
+        const payload = await response.json().catch(() => ({}));
+        const message = typeof payload?.error === "string" ? payload.error : "Error enviando KYC";
+        throw new Error(message);
+      }
+      toast.success("Enviamos tu información para revisión");
+      await onboarding.refresh();
+      router.push(`/select-org?orgId=${encodeURIComponent(companyId)}&status=submitted`);
+    } catch (err) {
+      console.error("kyc submit error", err);
+      setError(err instanceof Error ? err.message : "Error inesperado");
+      toast.error("No pudimos enviar la información");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const uploadedByType = useMemo(() => {
+    const map = new Map<string, number>();
+    documents.forEach((doc, index) => {
+      if (!doc.path) return;
+      const segments = doc.path.split("/");
+      const name = segments.pop();
+      if (!name) return;
+      const key = name.split("-")[0];
+      map.set(key, index);
+    });
+    return map;
+  }, [documents]);
+
+  const canSubmit = uploadedByType.size >= REQUIRED_DOCS.length;
+
+  return (
+    <div className="space-y-6">
+      {normalizedStatus === "SUBMITTED" ? (
+        <Alert>
+          <AlertTitle>En revisión</AlertTitle>
+          <AlertDescription>
+            Ya recibimos tu información. Te notificaremos cuando el proceso haya finalizado.
+          </AlertDescription>
+        </Alert>
+      ) : null}
+      {normalizedStatus === "APPROVED" ? (
+        <Alert>
+          <AlertTitle className="flex items-center gap-2">
+            <span className="inline-flex items-center rounded-full bg-emerald-100 px-2 py-1 text-xs font-semibold text-emerald-700">
+              Aprobado
+            </span>
+            KYC aprobado
+          </AlertTitle>
+          <AlertDescription>
+            ¡Felicitaciones! Tu registro fue aprobado. Puedes volver al portal para operar normalmente.
+          </AlertDescription>
+        </Alert>
+      ) : null}
+
+      {REQUIRED_DOCS.map((doc) => {
+        const index = uploadedByType.get(doc.key);
+        const uploaded = typeof index === "number" ? documents[index] : null;
+        return (
+          <div key={doc.key} className="rounded-xl border border-lp-sec-4/40 bg-white p-6 shadow-sm">
+            <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+              <div>
+                <h3 className="text-lg font-semibold text-lp-primary-1">{doc.label}</h3>
+                <p className="text-sm text-lp-sec-3">{doc.description}</p>
+                {uploaded ? (
+                  <p className="mt-2 text-sm text-lp-sec-2">
+                    Última carga: {uploaded.updatedAt ? new Date(uploaded.updatedAt).toLocaleString() : ""}
+                    {uploaded.size ? ` · ${formatBytes(uploaded.size)}` : ""}
+                  </p>
+                ) : (
+                  <p className="mt-2 text-sm text-lp-sec-2">Aún no se ha cargado este documento.</p>
+                )}
+              </div>
+              <div className="flex flex-col gap-2 md:items-end">
+                <Label className="cursor-pointer">
+                  <Input
+                    type="file"
+                    accept=".pdf,.jpg,.jpeg,.png"
+                    className="hidden"
+                    onChange={(event) => handleUpload(doc.key, event.target.files)}
+                    disabled={uploading[doc.key]}
+                  />
+                  <Button type="button" variant="outline" disabled={uploading[doc.key]}>
+                    {uploading[doc.key] ? "Cargando..." : uploaded ? "Reemplazar documento" : "Subir documento"}
+                  </Button>
+                </Label>
+                {uploaded ? (
+                  <Button type="button" variant="ghost" onClick={() => handleDelete(uploaded.path)}>
+                    Eliminar
+                  </Button>
+                ) : null}
+              </div>
+            </div>
+          </div>
+        );
+      })}
+
+      {error ? (
+        <Alert variant="destructive">
+          <AlertTitle>Error</AlertTitle>
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      ) : null}
+
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <Button type="button" variant="ghost" onClick={() => router.push(`/registro/beneficiarios?orgId=${encodeURIComponent(companyId)}`)} className="w-full sm:w-auto">
+          Volver
+        </Button>
+        <Button type="button" onClick={handleSubmit} disabled={submitting || !canSubmit} className="w-full sm:w-auto">
+          {submitting ? "Enviando..." : "Enviar a revisión"}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(auth)/registro/documentos/page.tsx
+++ b/src/app/(auth)/registro/documentos/page.tsx
@@ -1,0 +1,30 @@
+import { redirect } from "next/navigation";
+
+import { OnboardingShell } from "../_components/OnboardingShell";
+import { DocumentsStep } from "./DocumentsStep";
+
+type SearchParams = Record<string, string | string[] | undefined>;
+
+type DocumentosPageProps = {
+  searchParams?: Promise<SearchParams>;
+};
+
+export default async function DocumentosPage({ searchParams }: DocumentosPageProps) {
+  const params = (await searchParams) ?? {};
+  const orgParam = params.orgId;
+  const orgId = Array.isArray(orgParam) ? orgParam[0] : orgParam;
+  if (!orgId) {
+    redirect("/select-org?reason=missing-org");
+  }
+
+  return (
+    <OnboardingShell
+      companyId={orgId}
+      currentStep={2}
+      title="Documentación"
+      description="Adjunta los documentos y envíalos para revisión"
+    >
+      {(onboarding) => <DocumentsStep companyId={orgId} onboarding={onboarding} />}
+    </OnboardingShell>
+  );
+}

--- a/src/app/(auth)/registro/layout.tsx
+++ b/src/app/(auth)/registro/layout.tsx
@@ -1,0 +1,11 @@
+export default function RegistroLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="bg-lp-primary-2/10 py-12 sm:py-16">
+      <div className="container mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+        <div className="rounded-3xl border border-lp-sec-4/40 bg-white/80 p-6 shadow-lg backdrop-blur">
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(auth)/registro/page.tsx
+++ b/src/app/(auth)/registro/page.tsx
@@ -1,0 +1,17 @@
+import { redirect } from "next/navigation";
+
+type SearchParams = Record<string, string | string[] | undefined>;
+
+type RegistroIndexProps = {
+  searchParams?: Promise<SearchParams>;
+};
+
+export default async function RegistroIndex({ searchParams }: RegistroIndexProps) {
+  const params = (await searchParams) ?? {};
+  const orgParam = params.orgId;
+  const orgId = Array.isArray(orgParam) ? orgParam[0] : orgParam;
+  if (!orgId) {
+    redirect("/select-org?reason=missing-org");
+  }
+  redirect(`/registro/datos-empresa?orgId=${encodeURIComponent(orgId)}`);
+}

--- a/src/app/api/onboarding/[companyId]/documents/route.ts
+++ b/src/app/api/onboarding/[companyId]/documents/route.ts
@@ -1,0 +1,147 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import { canManageMembership, normalizeMemberRole } from "@/lib/rbac";
+import { supabaseAdmin } from "@/lib/supabase";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+async function requireSession() {
+  const cookieStore = cookies();
+  const supabase = createRouteHandlerClient({ cookies: () => cookieStore });
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+  return { supabase, session } as const;
+}
+
+async function ensureManager(
+  supabase: SupabaseClient,
+  companyId: string,
+  userId: string,
+) {
+  const { data, error } = await supabase
+    .from("memberships")
+    .select("role, status")
+    .eq("company_id", companyId)
+    .eq("user_id", userId)
+    .maybeSingle();
+  if (error) {
+    console.error("onboarding documents membership error", error);
+    throw new Error("membership_error");
+  }
+  if (!data || data.status !== "ACTIVE") {
+    return { allowed: false } as const;
+  }
+  const role = normalizeMemberRole(data.role);
+  if (!canManageMembership(role)) {
+    return { allowed: false } as const;
+  }
+  return { allowed: true } as const;
+}
+
+function sanitizeName(input: string): string {
+  return input
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-zA-Z0-9._-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "")
+    .toLowerCase();
+}
+
+export async function POST(
+  req: Request,
+  { params }: { params: { companyId: string } },
+) {
+  try {
+    const companyId = params.companyId;
+    if (!companyId) {
+      return NextResponse.json({ ok: false, error: "Missing company" }, { status: 400 });
+    }
+
+    const { supabase, session } = await requireSession();
+    if (!session) {
+      return NextResponse.json({ ok: false, error: "Unauthorized" }, { status: 401 });
+    }
+
+    const membership = await ensureManager(supabase, companyId, session.user.id);
+    if (!membership.allowed) {
+      return NextResponse.json({ ok: false, error: "Forbidden" }, { status: 403 });
+    }
+
+    const formData = await req.formData();
+    const file = formData.get("file");
+    if (!(file instanceof File)) {
+      return NextResponse.json({ ok: false, error: "Missing file" }, { status: 400 });
+    }
+
+    const typeValue = formData.get("type");
+    const type = typeof typeValue === "string" && typeValue.trim() ? typeValue.trim().toLowerCase() : "document";
+    const originalName = sanitizeName(file.name || `${type}.pdf`);
+    const timestamp = Date.now();
+    const path = `${companyId}/${type}-${timestamp}-${originalName}`;
+
+    const arrayBuffer = await file.arrayBuffer();
+    const buffer = Buffer.from(arrayBuffer);
+
+    const { error } = await supabaseAdmin.storage
+      .from("kyc-documents")
+      .upload(path, buffer, {
+        contentType: file.type || "application/octet-stream",
+        upsert: false,
+      });
+
+    if (error) {
+      console.error("onboarding document upload error", error);
+      return NextResponse.json({ ok: false, error: "upload_failed" }, { status: 500 });
+    }
+
+    return NextResponse.json({ ok: true, path });
+  } catch (error) {
+    console.error("POST /api/onboarding documents error", error);
+    return NextResponse.json({ ok: false, error: "unexpected" }, { status: 500 });
+  }
+}
+
+export async function DELETE(
+  req: Request,
+  { params }: { params: { companyId: string } },
+) {
+  try {
+    const companyId = params.companyId;
+    if (!companyId) {
+      return NextResponse.json({ ok: false, error: "Missing company" }, { status: 400 });
+    }
+
+    const { supabase, session } = await requireSession();
+    if (!session) {
+      return NextResponse.json({ ok: false, error: "Unauthorized" }, { status: 401 });
+    }
+
+    const membership = await ensureManager(supabase, companyId, session.user.id);
+    if (!membership.allowed) {
+      return NextResponse.json({ ok: false, error: "Forbidden" }, { status: 403 });
+    }
+
+    const body = await req.json().catch(() => null);
+    const path = body && typeof body.path === "string" ? body.path : null;
+    if (!path || !path.startsWith(`${companyId}/`)) {
+      return NextResponse.json({ ok: false, error: "Invalid path" }, { status: 400 });
+    }
+
+    const { error } = await supabaseAdmin.storage.from("kyc-documents").remove([path]);
+    if (error) {
+      console.error("onboarding document delete error", error);
+      return NextResponse.json({ ok: false, error: "delete_failed" }, { status: 500 });
+    }
+
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    console.error("DELETE /api/onboarding documents error", error);
+    return NextResponse.json({ ok: false, error: "unexpected" }, { status: 500 });
+  }
+}

--- a/src/app/api/onboarding/[companyId]/documents/route.ts
+++ b/src/app/api/onboarding/[companyId]/documents/route.ts
@@ -53,12 +53,11 @@ function sanitizeName(input: string): string {
     .toLowerCase();
 }
 
-export async function POST(
-  req: Request,
-  { params }: { params: { companyId: string } },
-) {
+type RouteContext = { params: Promise<{ companyId: string }> };
+
+export async function POST(req: Request, context: RouteContext) {
   try {
-    const companyId = params.companyId;
+    const { companyId } = await context.params;
     if (!companyId) {
       return NextResponse.json({ ok: false, error: "Missing company" }, { status: 400 });
     }
@@ -107,12 +106,9 @@ export async function POST(
   }
 }
 
-export async function DELETE(
-  req: Request,
-  { params }: { params: { companyId: string } },
-) {
+export async function DELETE(req: Request, context: RouteContext) {
   try {
-    const companyId = params.companyId;
+    const { companyId } = await context.params;
     if (!companyId) {
       return NextResponse.json({ ok: false, error: "Missing company" }, { status: 400 });
     }

--- a/src/app/api/onboarding/[companyId]/route.ts
+++ b/src/app/api/onboarding/[companyId]/route.ts
@@ -12,6 +12,8 @@ import { notifyStaffKycSubmitted, notifyClientKycApproved } from "@/lib/notifica
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
+type RouteContext = { params: Promise<{ companyId: string }> };
+
 async function requireSession() {
   const cookieStore = cookies();
   const supabase = createRouteHandlerClient({ cookies: () => cookieStore });
@@ -45,17 +47,14 @@ async function ensureMembership(supabase: SupabaseClient, companyId: string, use
   return { allowed: true, role: data.role ?? null };
 }
 
-export async function GET(
-  req: Request,
-  { params }: { params: { companyId: string } },
-) {
+export async function GET(req: Request, context: RouteContext) {
   try {
     const { supabase, session } = await requireSession();
     if (!session) {
       return NextResponse.json({ ok: false, error: "Unauthorized" }, { status: 401 });
     }
 
-    const companyId = params.companyId;
+    const { companyId } = await context.params;
     if (!companyId) {
       return NextResponse.json({ ok: false, error: "Missing company" }, { status: 400 });
     }
@@ -136,17 +135,14 @@ function sanitizeString(value: unknown): string | null {
   return trimmed.length ? trimmed : null;
 }
 
-export async function PUT(
-  req: Request,
-  { params }: { params: { companyId: string } },
-) {
+export async function PUT(req: Request, context: RouteContext) {
   try {
     const { supabase, session } = await requireSession();
     if (!session) {
       return NextResponse.json({ ok: false, error: "Unauthorized" }, { status: 401 });
     }
 
-    const companyId = params.companyId;
+    const { companyId } = await context.params;
     if (!companyId) {
       return NextResponse.json({ ok: false, error: "Missing company" }, { status: 400 });
     }

--- a/src/app/api/onboarding/[companyId]/route.ts
+++ b/src/app/api/onboarding/[companyId]/route.ts
@@ -1,0 +1,308 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import { normalizeMemberRole, canManageMembership } from "@/lib/rbac";
+import { normalizeKycStatus } from "@/lib/organizations";
+import { supabaseAdmin } from "@/lib/supabase";
+import { notifyStaffKycSubmitted, notifyClientKycApproved } from "@/lib/notifications";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+async function requireSession() {
+  const cookieStore = cookies();
+  const supabase = createRouteHandlerClient({ cookies: () => cookieStore });
+  const {
+    data: { session },
+    error,
+  } = await supabase.auth.getSession();
+  if (error) {
+    throw error;
+  }
+  if (!session) {
+    return { supabase, session: null } as const;
+  }
+  return { supabase, session } as const;
+}
+
+async function ensureMembership(supabase: SupabaseClient, companyId: string, userId: string) {
+  const { data, error } = await supabase
+    .from("memberships")
+    .select("role, status")
+    .eq("company_id", companyId)
+    .eq("user_id", userId)
+    .maybeSingle();
+  if (error) {
+    console.error("onboarding membership error", error);
+    throw new Error("membership_error");
+  }
+  if (!data || data.status !== "ACTIVE") {
+    return { allowed: false, role: null as string | null };
+  }
+  return { allowed: true, role: data.role ?? null };
+}
+
+export async function GET(
+  req: Request,
+  { params }: { params: { companyId: string } },
+) {
+  try {
+    const { supabase, session } = await requireSession();
+    if (!session) {
+      return NextResponse.json({ ok: false, error: "Unauthorized" }, { status: 401 });
+    }
+
+    const companyId = params.companyId;
+    if (!companyId) {
+      return NextResponse.json({ ok: false, error: "Missing company" }, { status: 400 });
+    }
+
+    const membership = await ensureMembership(supabase, companyId, session.user.id);
+    if (!membership.allowed) {
+      return NextResponse.json({ ok: false, error: "Forbidden" }, { status: 403 });
+    }
+
+    const { data: company, error: companyError } = await supabaseAdmin
+      .from("companies")
+      .select(
+        "id, name, legal_name, tax_id, contact_email, contact_phone, billing_email, bank_account, kyc_status, kyc_submitted_at, kyc_approved_at",
+      )
+      .eq("id", companyId)
+      .maybeSingle();
+    if (companyError) {
+      console.error("onboarding company load error", companyError);
+      return NextResponse.json({ ok: false, error: "company_fetch_failed" }, { status: 500 });
+    }
+
+    const { data: addresses, error: addressError } = await supabaseAdmin
+      .from("addresses")
+      .select("id, type, line1, line2, city, state, postal_code, country")
+      .eq("company_id", companyId);
+    if (addressError && addressError.code !== "42P01") {
+      console.error("onboarding address load error", addressError);
+      return NextResponse.json({ ok: false, error: "address_fetch_failed" }, { status: 500 });
+    }
+
+    const { data: owners, error: ownersError } = await supabaseAdmin
+      .from("beneficial_owners")
+      .select("id, full_name, document_type, document_number, email, ownership_percentage")
+      .eq("company_id", companyId);
+    if (ownersError && ownersError.code !== "42P01") {
+      console.error("onboarding owners load error", ownersError);
+      return NextResponse.json({ ok: false, error: "owners_fetch_failed" }, { status: 500 });
+    }
+
+    const { data: docs, error: docsError } = await supabaseAdmin.storage
+      .from("kyc-documents")
+      .list(companyId, { limit: 100, sortBy: { column: "created_at", order: "desc" } });
+    if (docsError && docsError.name !== "StorageApiError") {
+      console.error("onboarding documents load error", docsError);
+    }
+
+    const primaryAddress = Array.isArray(addresses)
+      ? addresses.find((addr) => (addr as { type?: string }).type === "LEGAL") ?? addresses[0] ?? null
+      : null;
+
+    const documentList = Array.isArray(docs)
+      ? docs.map((doc) => ({
+          name: doc.name,
+          path: `${companyId}/${doc.name}`,
+          createdAt: doc.created_at,
+          updatedAt: doc.updated_at,
+          size: doc.size,
+        }))
+      : [];
+
+    return NextResponse.json({
+      ok: true,
+      company,
+      address: primaryAddress,
+      owners: owners ?? [],
+      documents: documentList,
+      role: normalizeMemberRole(membership.role) ?? null,
+    });
+  } catch (error) {
+    console.error("GET /api/onboarding error", error);
+    return NextResponse.json({ ok: false, error: "unexpected" }, { status: 500 });
+  }
+}
+
+function sanitizeString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length ? trimmed : null;
+}
+
+export async function PUT(
+  req: Request,
+  { params }: { params: { companyId: string } },
+) {
+  try {
+    const { supabase, session } = await requireSession();
+    if (!session) {
+      return NextResponse.json({ ok: false, error: "Unauthorized" }, { status: 401 });
+    }
+
+    const companyId = params.companyId;
+    if (!companyId) {
+      return NextResponse.json({ ok: false, error: "Missing company" }, { status: 400 });
+    }
+
+    const membership = await ensureMembership(supabase, companyId, session.user.id);
+    const role = normalizeMemberRole(membership.role);
+    if (!membership.allowed || !canManageMembership(role)) {
+      return NextResponse.json({ ok: false, error: "Forbidden" }, { status: 403 });
+    }
+
+    const payload = await req.json().catch(() => null);
+    if (!payload || typeof payload !== "object") {
+      return NextResponse.json({ ok: false, error: "Invalid payload" }, { status: 400 });
+    }
+
+    const section = typeof (payload as { section?: unknown }).section === "string" ? (payload as { section: string }).section : "";
+
+    if (section === "company") {
+      const companyData = (payload as { company?: Record<string, unknown> }).company ?? {};
+      const updates: Record<string, unknown> = {
+        legal_name: sanitizeString(companyData.legalName),
+        tax_id: sanitizeString(companyData.taxId),
+        contact_email: sanitizeString(companyData.contactEmail),
+        contact_phone: sanitizeString(companyData.contactPhone),
+        billing_email: sanitizeString(companyData.billingEmail),
+        bank_account: sanitizeString(companyData.bankAccount),
+        updated_at: new Date().toISOString(),
+      };
+      const { error: updateError } = await supabaseAdmin
+        .from("companies")
+        .update(updates)
+        .eq("id", companyId);
+      if (updateError) {
+        console.error("onboarding company update error", updateError);
+        return NextResponse.json({ ok: false, error: "company_update_failed" }, { status: 500 });
+      }
+
+      if (companyData.address && typeof companyData.address === "object") {
+        const address = companyData.address as Record<string, unknown>;
+        const addressRow = {
+          company_id: companyId,
+          type: sanitizeString(address.type) ?? "LEGAL",
+          line1: sanitizeString(address.line1),
+          line2: sanitizeString(address.line2),
+          city: sanitizeString(address.city),
+          state: sanitizeString(address.state),
+          postal_code: sanitizeString(address.postalCode),
+          country: sanitizeString(address.country),
+          updated_at: new Date().toISOString(),
+        };
+        const { error: deleteError } = await supabaseAdmin
+          .from("addresses")
+          .delete()
+          .eq("company_id", companyId)
+          .eq("type", addressRow.type ?? "LEGAL");
+        if (deleteError && deleteError.code !== "42P01") {
+          console.error("onboarding address delete error", deleteError);
+          return NextResponse.json({ ok: false, error: "address_update_failed" }, { status: 500 });
+        }
+        if (addressRow.line1) {
+          const { error: addressInsertError } = await supabaseAdmin
+            .from("addresses")
+            .insert(addressRow);
+          if (addressInsertError && addressInsertError.code !== "42P01") {
+            console.error("onboarding address update error", addressInsertError);
+            return NextResponse.json({ ok: false, error: "address_update_failed" }, { status: 500 });
+          }
+        }
+      }
+
+      return NextResponse.json({ ok: true });
+    }
+
+    if (section === "owners") {
+      const owners = Array.isArray((payload as { owners?: unknown }).owners)
+        ? ((payload as { owners: unknown[] }).owners).map((owner) => owner ?? {})
+        : [];
+
+      const { error: ownersDeleteError } = await supabaseAdmin.from("beneficial_owners").delete().eq("company_id", companyId);
+      if (ownersDeleteError && ownersDeleteError.code !== "42P01") {
+        console.error("onboarding owners delete error", ownersDeleteError);
+        return NextResponse.json({ ok: false, error: "owners_update_failed" }, { status: 500 });
+      }
+
+      const rows = owners
+        .map((owner) => ({
+          full_name: sanitizeString((owner as Record<string, unknown>).fullName),
+          document_type: sanitizeString((owner as Record<string, unknown>).documentType),
+          document_number: sanitizeString((owner as Record<string, unknown>).documentNumber),
+          email: sanitizeString((owner as Record<string, unknown>).email),
+          ownership_percentage: typeof (owner as Record<string, unknown>).ownershipPercentage === "number"
+            ? (owner as Record<string, unknown>).ownershipPercentage
+            : parseFloat(String((owner as Record<string, unknown>).ownershipPercentage ?? "")) || null,
+        }))
+        .filter((row) => row.full_name && row.document_number);
+
+      if (rows.length) {
+        const insertRows = rows.map((row) => ({ ...row, company_id: companyId }));
+        const { error: insertError } = await supabaseAdmin.from("beneficial_owners").insert(insertRows);
+        if (insertError && insertError.code !== "42P01") {
+          console.error("onboarding owners insert error", insertError);
+          return NextResponse.json({ ok: false, error: "owners_update_failed" }, { status: 500 });
+        }
+      }
+
+      return NextResponse.json({ ok: true });
+    }
+
+    if (section === "status") {
+      const nextStatus = normalizeKycStatus((payload as { status?: unknown }).status ?? null);
+      if (!nextStatus) {
+        return NextResponse.json({ ok: false, error: "Invalid status" }, { status: 400 });
+      }
+
+      const { data: current, error: currentError } = await supabaseAdmin
+        .from("companies")
+        .select("kyc_status")
+        .eq("id", companyId)
+        .maybeSingle();
+      if (currentError) {
+        console.error("onboarding status load error", currentError);
+        return NextResponse.json({ ok: false, error: "status_fetch_failed" }, { status: 500 });
+      }
+
+      const previousStatus = normalizeKycStatus(current?.kyc_status ?? null);
+
+      const updateData: Record<string, unknown> = { kyc_status: nextStatus, updated_at: new Date().toISOString() };
+      if (nextStatus === "SUBMITTED") {
+        updateData.kyc_submitted_at = new Date().toISOString();
+      }
+      if (nextStatus === "APPROVED") {
+        updateData.kyc_approved_at = new Date().toISOString();
+      }
+
+      const { error: updateError } = await supabaseAdmin
+        .from("companies")
+        .update(updateData)
+        .eq("id", companyId);
+      if (updateError) {
+        console.error("onboarding status update error", updateError);
+        return NextResponse.json({ ok: false, error: "status_update_failed" }, { status: 500 });
+      }
+
+      if (nextStatus === "SUBMITTED" && previousStatus !== "SUBMITTED") {
+        await notifyStaffKycSubmitted(companyId);
+      }
+      if (nextStatus === "APPROVED" && previousStatus !== "APPROVED") {
+        await notifyClientKycApproved(companyId);
+      }
+
+      return NextResponse.json({ ok: true, status: nextStatus });
+    }
+
+    return NextResponse.json({ ok: false, error: "Unknown section" }, { status: 400 });
+  } catch (error) {
+    console.error("PUT /api/onboarding error", error);
+    return NextResponse.json({ ok: false, error: "unexpected" }, { status: 500 });
+  }
+}

--- a/src/app/api/orgs/route.ts
+++ b/src/app/api/orgs/route.ts
@@ -15,10 +15,10 @@ export async function GET() {
 
   const { data, error } = await supabase
     .from("memberships")
-    .select("role, status, company_id, companies ( id, name, type )")
+    .select("role, status, company_id, companies ( id, name, type, kyc_status )")
     .order("created_at", { ascending: false });
   if (error) return NextResponse.json({ ok: false, error: error.message }, { status: 500 });
-  type Company = { id: string; name: string; type: string };
+  type Company = { id: string; name: string; type: string; kyc_status?: string | null };
   type Row = { role: string; status: string; companies: Company | Company[] | null };
   const orgs = (data ?? []).map((m: Row) => {
     const c = Array.isArray(m.companies) ? m.companies[0] : m.companies;
@@ -28,6 +28,7 @@ export async function GET() {
       type: c?.type,
       role: m.role,
       status: m.status,
+      kycStatus: c?.kyc_status ?? null,
     };
   });
   return NextResponse.json({ ok: true, orgs });

--- a/src/app/app/page.tsx
+++ b/src/app/app/page.tsx
@@ -1,16 +1,65 @@
-export default function AppPage() {
+import { redirect } from "next/navigation";
+
+import { supabaseServer } from "@/lib/supabase-server";
+import { normalizeKycStatus } from "@/lib/organizations";
+
+type SearchParams = Record<string, string | string[] | undefined>;
+
+type AppPageProps = {
+  searchParams?: Promise<SearchParams>;
+};
+
+export default async function AppPage({ searchParams }: AppPageProps) {
+  const params = (await searchParams) ?? {};
+  const orgParam = params.orgId;
+  const orgId = Array.isArray(orgParam) ? orgParam[0] : orgParam;
+
+  const supabase = await supabaseServer();
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  if (!session) {
+    redirect(`/login?redirectTo=${encodeURIComponent("/app")}`);
+  }
+
+  if (!orgId) {
+    redirect("/select-org");
+  }
+
+  const { data: membership } = await supabase
+    .from("memberships")
+    .select("status, companies ( id, name, kyc_status )")
+    .eq("company_id", orgId)
+    .eq("user_id", session.user.id)
+    .maybeSingle();
+
+  if (!membership || membership.status !== "ACTIVE") {
+    redirect("/select-org?reason=no-membership");
+  }
+
+  const company = Array.isArray(membership.companies) ? membership.companies[0] : membership.companies;
+  const kycStatus = normalizeKycStatus(company?.kyc_status ?? null);
+
+  if (kycStatus !== "APPROVED") {
+    redirect(`/registro/datos-empresa?orgId=${encodeURIComponent(orgId)}`);
+  }
+
+  const companyName = typeof company?.name === "string" && company.name.trim() ? company.name : "Tu empresa";
+
   return (
     <div className="py-20 sm:py-24">
       <div className="container mx-auto max-w-3xl px-4 sm:px-6 lg:px-8 text-center">
         <h1 className="font-colette text-3xl font-bold tracking-tight text-lp-primary-1 sm:text-4xl">
-          Dashboard de Usuario
+          Bienvenido al portal
         </h1>
         <p className="mt-4 text-lg leading-8 text-lp-sec-3">
-          Aquí podrás gestionar tus facturas, ver el estado de tus operaciones y acceder a tu historial.
+          {companyName} ya tiene un KYC aprobado. Pronto podrás gestionar facturas y operaciones desde este espacio.
         </p>
         <div className="mt-10">
           <p className="text-base text-lp-sec-3">
-            (Esta es una maqueta de UI. La funcionalidad de autenticación y gestión de facturas se implementará en fases posteriores.)
+            Mientras activamos las funcionalidades principales, puedes volver al selector de organizaciones para explorar otras
+            cuentas.
           </p>
         </div>
       </div>

--- a/src/app/c/[orgId]/layout.tsx
+++ b/src/app/c/[orgId]/layout.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
+import { redirect } from "next/navigation";
 import { supabaseServer } from "@/lib/supabase-server";
-import { getOrganizationDisplayName } from "@/lib/organizations";
+import { getOrganizationDisplayName, getOrganizationKycStatus, isKycCompleted } from "@/lib/organizations";
 
 export default async function ClientPortalLayout({
   children,
@@ -18,6 +19,11 @@ export default async function ClientPortalLayout({
 
   const orgName = await getOrganizationDisplayName(supabase, orgId, session?.user?.id ?? null);
   const displayOrg = orgName ?? orgId;
+
+  const kycStatus = await getOrganizationKycStatus(supabase, orgId);
+  if (!isKycCompleted(kycStatus)) {
+    redirect(`/registro/datos-empresa?orgId=${encodeURIComponent(orgId)}`);
+  }
 
   const links = [
     { href: `/c/${orgId}`, label: "Resumen" },

--- a/src/app/select-org/page.tsx
+++ b/src/app/select-org/page.tsx
@@ -6,7 +6,25 @@ import { useSearchParams, useRouter } from "next/navigation";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import { OrgCreator } from "./OrgCreator";
 
-type Org = { id: string; name: string; type: string; role: string; status?: string };
+type Org = { id: string; name: string; type: string; role: string; status?: string; kycStatus?: string | null };
+
+function formatKycStatus(status: string | null | undefined): string {
+  if (!status) return "Sin iniciar";
+  const upper = status.toUpperCase();
+  switch (upper) {
+    case "APPROVED":
+      return "Aprobado";
+    case "SUBMITTED":
+      return "En revisión";
+    case "IN_PROGRESS":
+    case "PENDING":
+      return "En progreso";
+    case "REJECTED":
+      return "Rechazado";
+    default:
+      return status;
+  }
+}
 
 function SelectOrgInner() {
   const [orgs, setOrgs] = useState<Org[]>([]);
@@ -56,19 +74,37 @@ function SelectOrgInner() {
                 Aun no perteneces a ninguna organizacion.
               </div>
             )}
-            {orgs.map((o) => (
-              <div key={o.id} className="flex items-center justify-between rounded-md border border-lp-sec-4/60 p-4">
-                <div>
-                  <div className="font-semibold text-lp-primary-1">{o.name}</div>
-                  <div className="text-sm text-lp-sec-3">{o.type} · Rol: {o.role} · Estado: {o.status || 'ACTIVE'}</div>
+            {orgs.map((o) => {
+              const isActive = o.status === "ACTIVE" || !o.status;
+              const isKycApproved = (o.kycStatus ?? "").toUpperCase() === "APPROVED";
+              return (
+                <div key={o.id} className="flex items-center justify-between rounded-md border border-lp-sec-4/60 p-4">
+                  <div>
+                    <div className="font-semibold text-lp-primary-1">{o.name}</div>
+                    <div className="text-sm text-lp-sec-3">
+                      {o.type} · Rol: {o.role} · Estado: {o.status || "ACTIVE"} · KYC: {formatKycStatus(o.kycStatus)}
+                    </div>
+                  </div>
+                  {isActive && isKycApproved ? (
+                    <Link
+                      href={`/c/${o.id}`}
+                      className="rounded-md bg-lp-primary-1 px-4 py-2 text-sm font-medium text-lp-primary-2 hover:opacity-90"
+                    >
+                      Entrar
+                    </Link>
+                  ) : isActive ? (
+                    <Link
+                      href={`/registro/datos-empresa?orgId=${o.id}`}
+                      className="rounded-md border border-lp-primary-1 px-4 py-2 text-sm font-medium text-lp-primary-1 hover:bg-lp-primary-1/10"
+                    >
+                      Completar registro
+                    </Link>
+                  ) : (
+                    <span className="text-sm text-lp-sec-3">Pendiente de habilitación</span>
+                  )}
                 </div>
-                {o.status === 'ACTIVE' || !o.status ? (
-                  <Link href={`/c/${o.id}`} className="rounded-md bg-lp-primary-1 px-4 py-2 text-sm font-medium text-lp-primary-2 hover:opacity-90">Entrar</Link>
-                ) : (
-                  <span className="text-sm text-lp-sec-3">Pendiente de habilitación</span>
-                )}
-              </div>
-            ))}
+              );
+            })}
           </div>
         )}
 

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -130,3 +130,20 @@ export async function notifyClientNeedsDocs(companyId: string, note?: string) {
   const html = `<p>Necesitamos documentos adicionales para continuar.</p>${note ? `<p>${note}</p>` : ''}`;
   await sendEmail(recipients, subject, html);
 }
+
+export async function notifyStaffKycSubmitted(companyId: string) {
+  const staff = staffRecipients();
+  if (!staff.length) return;
+  const subject = `Nuevo KYC en revisión (${companyId})`;
+  const html = `<p>Una empresa completó su registro y requiere revisión de KYC.</p><p>Empresa: <code>${companyId}</code></p>`;
+  await sendEmail(staff, subject, html);
+}
+
+export async function notifyClientKycApproved(companyId: string) {
+  const { admins, clients } = await getCompanyActiveMemberEmails(companyId);
+  const recipients = clients.length ? clients : admins;
+  if (!recipients.length) return;
+  const subject = `Registro aprobado`;
+  const html = `<p>¡Tu registro KYC ha sido aprobado! Ya puedes operar sin restricciones.</p>`;
+  await sendEmail(recipients, subject, html);
+}


### PR DESCRIPTION
## Summary
- add a public onboarding route group with multistep forms for company data, beneficiaries, and documents
- expose onboarding APIs to persist legal information, manage KYC files, and trigger status notifications
- surface KYC status in org selection and gate customer portal access until approval

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dcef8dfe90832fba1fc2080df4f57d