### PR TITLE
Add request timelines and collections management

### DIFF
--- a/src/app/api/collections/[id]/route.ts
+++ b/src/app/api/collections/[id]/route.ts
@@ -1,0 +1,268 @@
+import { NextResponse } from "next/server";
+
+import { supabaseServer } from "@/lib/supabase-server";
+import { supabaseAdmin } from "@/lib/supabase";
+import { isBackofficeAllowed } from "@/lib/hq-auth";
+import {
+  CollectionCaseSummary,
+  createCollectionAction,
+  getCollectionCaseSummary,
+  updateCollectionCase,
+} from "@/lib/collections";
+import {
+  computeClientNextSteps,
+  createRequestEvent,
+  createRequestMessageAdmin,
+  getRequestTimeline,
+} from "@/lib/request-timeline";
+import {
+  notifyClientRequestMessage,
+  notifyStaffCollectionPromise,
+} from "@/lib/notifications";
+
+export const dynamic = "force-dynamic";
+
+async function ensureStaffSession() {
+  const supabase = await supabaseServer();
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+  if (!session) {
+    return { ok: false as const, response: NextResponse.json({ ok: false, error: "Unauthorized" }, { status: 401 }) };
+  }
+
+  const allowed = await isBackofficeAllowed(session.user?.id, session.user?.email);
+  if (!allowed) {
+    return { ok: false as const, response: NextResponse.json({ ok: false, error: "Forbidden" }, { status: 403 }) };
+  }
+
+  return { ok: true as const, supabase, session };
+}
+
+async function fetchCaseSummary(caseId: string): Promise<CollectionCaseSummary | null> {
+  return getCollectionCaseSummary(supabaseAdmin, caseId);
+}
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const guard = await ensureStaffSession();
+  if (!guard.ok) return guard.response;
+
+  try {
+    const { id } = await params;
+    const summary = await fetchCaseSummary(id);
+    if (!summary) {
+      return NextResponse.json({ ok: false, error: "Not found" }, { status: 404 });
+    }
+
+    const timeline = await getRequestTimeline(supabaseAdmin, summary.request_id);
+    const { data: actions, error: actionsError } = await supabaseAdmin
+      .from("collection_actions")
+      .select("*")
+      .eq("case_id", summary.id)
+      .order("created_at", { ascending: true });
+
+    if (actionsError) throw new Error(actionsError.message);
+
+    const nextSteps = computeClientNextSteps(summary.request_status, summary);
+
+    return NextResponse.json({
+      ok: true,
+      case: summary,
+      actions: actions ?? [],
+      timeline,
+      nextSteps,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unexpected error";
+    console.error("GET /api/collections/[id]", message);
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  }
+}
+
+export async function PATCH(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const guard = await ensureStaffSession();
+  if (!guard.ok) return guard.response;
+
+  try {
+    const { id } = await params;
+    const summary = await fetchCaseSummary(id);
+    if (!summary) {
+      return NextResponse.json({ ok: false, error: "Not found" }, { status: 404 });
+    }
+
+    const payload = await req.json();
+    const allowedFields = [
+      "status",
+      "priority",
+      "assigned_to",
+      "notes",
+      "closed_at",
+      "next_action_at",
+      "promise_amount",
+      "promise_date",
+    ];
+
+    const updates: Record<string, unknown> = {};
+    for (const key of allowedFields) {
+      if (key in payload) updates[key] = payload[key];
+    }
+
+    if (Object.keys(updates).length === 0) {
+      return NextResponse.json({ ok: false, error: "Sin cambios" }, { status: 400 });
+    }
+
+    const updated = await updateCollectionCase(id, updates);
+    if (!updated) throw new Error("No se pudo actualizar el caso");
+
+    await createRequestEvent({
+      requestId: summary.request_id,
+      companyId: summary.company_id,
+      eventType: "collection_update",
+      status: String(updates.status ?? updated.status ?? ""),
+      title: "Actualización de cobranza",
+      description: "Se actualizó la información del caso de cobranza.",
+      actorRole: "staff",
+      actorId: guard.session.user.id,
+      actorName: guard.session.user.email ?? null,
+      metadata: updates,
+    });
+
+    if ("promise_date" in updates || "promise_amount" in updates) {
+      await notifyStaffCollectionPromise(
+        summary.company_id,
+        summary.request_id,
+        (updates.promise_date as string | undefined) ?? updated.promise_date,
+        (updates.promise_amount as string | number | undefined) ?? updated.promise_amount,
+      );
+    }
+
+    const timeline = await getRequestTimeline(supabaseAdmin, summary.request_id);
+
+    return NextResponse.json({
+      ok: true,
+      case: updated,
+      timeline,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unexpected error";
+    console.error("PATCH /api/collections/[id]", message);
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  }
+}
+
+export async function POST(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const guard = await ensureStaffSession();
+  if (!guard.ok) return guard.response;
+
+  try {
+    const { id } = await params;
+    const summary = await fetchCaseSummary(id);
+    if (!summary) {
+      return NextResponse.json({ ok: false, error: "Not found" }, { status: 404 });
+    }
+
+    const payload = await req.json();
+    const kind = typeof payload?.kind === "string" ? payload.kind : "";
+
+    if (kind === "action") {
+      if (!payload?.actionType) {
+        return NextResponse.json({ ok: false, error: "Tipo de acción requerido" }, { status: 400 });
+      }
+
+      const action = await createCollectionAction({
+        caseId: summary.id,
+        requestId: summary.request_id,
+        companyId: summary.company_id,
+        actionType: String(payload.actionType),
+        note: typeof payload.note === "string" ? payload.note : null,
+        dueAt: typeof payload.dueAt === "string" ? payload.dueAt : null,
+        completedAt: typeof payload.completedAt === "string" ? payload.completedAt : null,
+        createdBy: guard.session.user.id,
+        createdByName: guard.session.user.email ?? null,
+        metadata: payload.metadata && typeof payload.metadata === "object" ? payload.metadata : null,
+      });
+
+      await createRequestEvent({
+        requestId: summary.request_id,
+        companyId: summary.company_id,
+        eventType: "collection_action",
+        status: summary.status,
+        title: `Acción de cobranza: ${action.action_type}`,
+        description: action.note ?? undefined,
+        actorRole: "staff",
+        actorId: guard.session.user.id,
+        actorName: guard.session.user.email ?? null,
+        metadata: { id: action.id, due_at: action.due_at, completed_at: action.completed_at },
+      });
+
+      return NextResponse.json({ ok: true, action });
+    }
+
+    if (kind === "message") {
+      const message = typeof payload?.message === "string" ? payload.message.trim() : "";
+      if (!message) {
+        return NextResponse.json({ ok: false, error: "Mensaje requerido" }, { status: 400 });
+      }
+
+      const visibility = payload?.visibility === "internal" ? "internal" : "client";
+      const subject = typeof payload?.subject === "string" && payload.subject.trim() ? payload.subject.trim() : null;
+
+      await createRequestMessageAdmin({
+        requestId: summary.request_id,
+        companyId: summary.company_id,
+        body: message,
+        subject,
+        visibility,
+        messageType: payload?.messageType ?? "note",
+        senderId: guard.session.user.id,
+        senderRole: "staff",
+        senderName: guard.session.user.email ?? null,
+      });
+
+      if (visibility !== "internal") {
+        await notifyClientRequestMessage(summary.company_id, summary.request_id, message);
+      }
+
+      const timeline = await getRequestTimeline(supabaseAdmin, summary.request_id);
+      return NextResponse.json({ ok: true, timeline });
+    }
+
+    if (kind === "event") {
+      if (!payload?.eventType) {
+        return NextResponse.json({ ok: false, error: "Tipo de evento requerido" }, { status: 400 });
+      }
+
+      const event = await createRequestEvent({
+        requestId: summary.request_id,
+        companyId: summary.company_id,
+        eventType: String(payload.eventType),
+        status: typeof payload.status === "string" ? payload.status : null,
+        title: typeof payload.title === "string" ? payload.title : null,
+        description: typeof payload.description === "string" ? payload.description : null,
+        actorRole: "staff",
+        actorId: guard.session.user.id,
+        actorName: guard.session.user.email ?? null,
+        occurredAt: typeof payload.occurredAt === "string" ? payload.occurredAt : null,
+        metadata: payload.metadata && typeof payload.metadata === "object" ? payload.metadata : null,
+      });
+
+      return NextResponse.json({ ok: true, event });
+    }
+
+    return NextResponse.json({ ok: false, error: "Operación no soportada" }, { status: 400 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unexpected error";
+    console.error("POST /api/collections/[id]", message);
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  }
+}
+

--- a/src/app/api/requests/[id]/timeline/route.ts
+++ b/src/app/api/requests/[id]/timeline/route.ts
@@ -1,0 +1,155 @@
+import { NextResponse } from "next/server";
+
+import { supabaseServer } from "@/lib/supabase-server";
+import { computeClientNextSteps, createRequestMessage, getRequestTimeline } from "@/lib/request-timeline";
+import { notifyStaffRequestMessage } from "@/lib/notifications";
+
+export const dynamic = "force-dynamic";
+
+async function ensureRequestAccess(
+  supabase: Awaited<ReturnType<typeof supabaseServer>>,
+  requestId: string,
+  userId: string,
+) {
+  const { data: request, error } = await supabase
+    .from("funding_requests")
+    .select("id, company_id, status, requested_amount, created_at")
+    .eq("id", requestId)
+    .maybeSingle();
+
+  if (error) throw new Error(error.message);
+  if (!request) return null;
+
+  const { data: membership, error: membershipError } = await supabase
+    .from("memberships")
+    .select("id")
+    .eq("company_id", request.company_id)
+    .eq("user_id", userId)
+    .limit(1);
+
+  if (membershipError) throw new Error(membershipError.message);
+  if (!membership || membership.length === 0) return null;
+
+  return request as { id: string; company_id: string; status: string; requested_amount: number; created_at: string };
+}
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { id } = await params;
+    const supabase = await supabaseServer();
+    const {
+      data: { session },
+    } = await supabase.auth.getSession();
+
+    if (!session) {
+      return NextResponse.json({ ok: false, error: "Unauthorized" }, { status: 401 });
+    }
+
+    const request = await ensureRequestAccess(supabase, id, session.user.id);
+    if (!request) {
+      return NextResponse.json({ ok: false, error: "Not found" }, { status: 404 });
+    }
+
+    const timeline = await getRequestTimeline(supabase, id);
+
+    const { data: collectionCase } = await supabase
+      .from("collection_cases")
+      .select("id, status, next_action_at, promise_amount, promise_date, closed_at")
+      .eq("request_id", id)
+      .order("opened_at", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    const nextSteps = computeClientNextSteps(request.status, collectionCase);
+
+    return NextResponse.json({
+      ok: true,
+      request,
+      timeline,
+      collectionCase,
+      nextSteps,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unexpected error";
+    console.error("GET /api/requests/[id]/timeline", message);
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  }
+}
+
+export async function POST(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { id } = await params;
+    const supabase = await supabaseServer();
+    const {
+      data: { session },
+    } = await supabase.auth.getSession();
+
+    if (!session) {
+      return NextResponse.json({ ok: false, error: "Unauthorized" }, { status: 401 });
+    }
+
+    const request = await ensureRequestAccess(supabase, id, session.user.id);
+    if (!request) {
+      return NextResponse.json({ ok: false, error: "Not found" }, { status: 404 });
+    }
+
+    const payload = await req.json();
+    const message = typeof payload?.message === "string" ? payload.message.trim() : "";
+    if (!message) {
+      return NextResponse.json({ ok: false, error: "Mensaje requerido" }, { status: 400 });
+    }
+
+    const subject = typeof payload?.subject === "string" && payload.subject.trim() ? payload.subject.trim() : null;
+    const visibility = payload?.visibility === "internal" ? "internal" : "client";
+
+    const senderName =
+      (typeof session.user.user_metadata === "object" && session.user.user_metadata && "full_name" in session.user.user_metadata)
+        ? String(session.user.user_metadata.full_name)
+        : session.user.email ?? null;
+
+    await createRequestMessage(supabase, {
+      requestId: id,
+      companyId: request.company_id,
+      body: message,
+      subject,
+      visibility,
+      messageType: payload?.messageType ?? null,
+      senderId: session.user.id,
+      senderRole: "client",
+      senderName,
+    });
+
+    if (visibility === "client") {
+      await notifyStaffRequestMessage(request.company_id, id, message);
+    }
+
+    const timeline = await getRequestTimeline(supabase, id);
+    const { data: collectionCase } = await supabase
+      .from("collection_cases")
+      .select("id, status, next_action_at, promise_amount, promise_date, closed_at")
+      .eq("request_id", id)
+      .order("opened_at", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    const nextSteps = computeClientNextSteps(request.status, collectionCase);
+
+    return NextResponse.json({
+      ok: true,
+      timeline,
+      collectionCase,
+      nextSteps,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unexpected error";
+    console.error("POST /api/requests/[id]/timeline", message);
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  }
+}
+

--- a/src/app/app/(requests)/[requestId]/timeline/page.tsx
+++ b/src/app/app/(requests)/[requestId]/timeline/page.tsx
@@ -1,0 +1,123 @@
+import { notFound } from "next/navigation";
+
+import { TimelineComposer } from "@/components/app/timeline/TimelineComposer";
+import { TimelineFeed } from "@/components/app/timeline/TimelineFeed";
+import { TimelineNextSteps } from "@/components/app/timeline/TimelineNextSteps";
+import { TimelineRealtimeBridge } from "@/components/app/timeline/TimelineRealtimeBridge";
+import { computeClientNextSteps, getRequestTimeline } from "@/lib/request-timeline";
+import { supabaseServer } from "@/lib/supabase-server";
+
+export const dynamic = "force-dynamic";
+
+function formatCurrency(value: number | string | null | undefined, currency?: string | null) {
+  if (value === null || value === undefined) return "-";
+  const amount = typeof value === "string" ? Number(value) : value;
+  if (!Number.isFinite(amount)) return String(value);
+  const formatter = new Intl.NumberFormat("es-CO", {
+    style: "currency",
+    currency: currency || "COP",
+    maximumFractionDigits: 0,
+  });
+  return formatter.format(amount);
+}
+
+export default async function RequestTimelinePage({
+  params,
+}: {
+  params: Promise<{ requestId: string }>;
+}) {
+  const { requestId } = await params;
+  const supabase = await supabaseServer();
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  if (!session) {
+    return (
+      <div className="py-10">
+        <div className="container mx-auto max-w-3xl px-4 sm:px-6 lg:px-8">
+          <div className="rounded-md border border-amber-200 bg-amber-50 p-4 text-sm text-amber-700">
+            Inicia sesión para consultar el historial de tu solicitud.
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const { data: request, error } = await supabase
+    .from("funding_requests")
+    .select("id, company_id, status, requested_amount, currency, created_at")
+    .eq("id", requestId)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  if (!request) {
+    notFound();
+  }
+
+  const { data: membership } = await supabase
+    .from("memberships")
+    .select("id")
+    .eq("company_id", request.company_id)
+    .eq("user_id", session.user.id)
+    .maybeSingle();
+
+  if (!membership) {
+    notFound();
+  }
+
+  const timeline = await getRequestTimeline(supabase, requestId);
+
+  const { data: collectionCase } = await supabase
+    .from("collection_cases")
+    .select("id, status, next_action_at, promise_amount, promise_date, closed_at")
+    .eq("request_id", requestId)
+    .order("opened_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  const nextSteps = computeClientNextSteps(request.status, collectionCase);
+
+  return (
+    <div className="py-10">
+      <div className="container mx-auto max-w-4xl space-y-6 px-4 sm:px-6 lg:px-8">
+        <header className="rounded-lg border border-neutral-200 bg-white p-6 shadow-sm">
+          <h1 className="font-colette text-2xl font-semibold text-lp-primary-1">Historial de la solicitud</h1>
+          <p className="mt-2 text-sm text-neutral-600">
+            Aquí encontrarás hitos, mensajes y recordatorios asociados a tu operación.
+          </p>
+          <dl className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-3">
+            <div>
+              <dt className="text-xs uppercase tracking-wide text-neutral-500">Monto</dt>
+              <dd className="text-base font-semibold text-neutral-900">
+                {formatCurrency(request.requested_amount, request.currency)}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-xs uppercase tracking-wide text-neutral-500">Estatus</dt>
+              <dd className="text-base font-semibold capitalize text-neutral-900">{request.status}</dd>
+            </div>
+            <div>
+              <dt className="text-xs uppercase tracking-wide text-neutral-500">Creada</dt>
+              <dd className="text-base font-semibold text-neutral-900">
+                {new Date(request.created_at).toLocaleDateString("es-CO")}
+              </dd>
+            </div>
+          </dl>
+        </header>
+
+        <TimelineNextSteps status={request.status} nextSteps={nextSteps} />
+
+        <TimelineComposer requestId={requestId} />
+
+        <TimelineFeed items={timeline} />
+
+        <TimelineRealtimeBridge requestId={requestId} />
+      </div>
+    </div>
+  );
+}
+

--- a/src/app/hq/collections/[caseId]/page.tsx
+++ b/src/app/hq/collections/[caseId]/page.tsx
@@ -1,0 +1,160 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import { TimelineFeed } from "@/components/app/timeline/TimelineFeed";
+import { TimelineRealtimeBridge } from "@/components/app/timeline/TimelineRealtimeBridge";
+import { TimelineNextSteps } from "@/components/app/timeline/TimelineNextSteps";
+import { supabaseServer } from "@/lib/supabase-server";
+import { supabaseAdmin } from "@/lib/supabase";
+import { isBackofficeAllowed } from "@/lib/hq-auth";
+import { getCollectionCaseSummary, listCollectionActions } from "@/lib/collections";
+import { computeClientNextSteps, getRequestTimeline } from "@/lib/request-timeline";
+
+import { CaseUpdateForm } from "./ui/CaseUpdateForm";
+import { CaseActionForm } from "./ui/CaseActionForm";
+import { CaseMessageForm } from "./ui/CaseMessageForm";
+
+function formatDate(value: string | null | undefined) {
+  if (!value) return "-";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return new Intl.DateTimeFormat("es-CO", { dateStyle: "medium", timeStyle: "short" }).format(date);
+}
+
+export const dynamic = "force-dynamic";
+
+export default async function CollectionCasePage({
+  params,
+}: {
+  params: Promise<{ caseId: string }>;
+}) {
+  const { caseId } = await params;
+  const supabase = await supabaseServer();
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  const allowed = session ? await isBackofficeAllowed(session.user?.id, session.user?.email) : false;
+  if (!allowed) {
+    return (
+      <div className="py-10">
+        <div className="container mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
+          <div className="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+            No tienes permiso para ver esta sección.
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const summary = await getCollectionCaseSummary(supabaseAdmin, caseId);
+  if (!summary) {
+    notFound();
+  }
+
+  const [timeline, actions] = await Promise.all([
+    getRequestTimeline(supabaseAdmin, summary.request_id),
+    listCollectionActions(supabaseAdmin, caseId),
+  ]);
+
+  const nextSteps = computeClientNextSteps(summary.request_status, summary);
+
+  return (
+    <div className="py-10">
+      <div className="container mx-auto max-w-6xl space-y-6 px-4 sm:px-6 lg:px-8">
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="font-colette text-3xl font-bold text-lp-primary-1">Caso de cobranza</h1>
+            <p className="mt-1 text-sm text-neutral-600">
+              Seguimiento de recordatorios, promesas y comunicaciones asociadas.
+            </p>
+          </div>
+          <Link href="/hq/collections" className="text-sm text-lp-primary-1 hover:underline">
+            ← Volver al listado
+          </Link>
+        </div>
+
+        <section className="grid gap-6 lg:grid-cols-3">
+          <div className="rounded-lg border border-neutral-200 bg-white p-5 shadow-sm lg:col-span-2">
+            <h2 className="text-lg font-semibold text-neutral-900">Resumen del caso</h2>
+            <dl className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
+              <div>
+                <dt className="text-xs uppercase tracking-wide text-neutral-500">Empresa</dt>
+                <dd className="text-sm font-medium text-neutral-900">{summary.company_name || summary.company_id}</dd>
+              </div>
+              <div>
+                <dt className="text-xs uppercase tracking-wide text-neutral-500">Solicitud</dt>
+                <dd className="text-sm font-medium text-neutral-900">{summary.request_id}</dd>
+              </div>
+              <div>
+                <dt className="text-xs uppercase tracking-wide text-neutral-500">Abierto</dt>
+                <dd className="text-sm text-neutral-700">{formatDate(summary.opened_at)}</dd>
+              </div>
+              <div>
+                <dt className="text-xs uppercase tracking-wide text-neutral-500">Próxima acción</dt>
+                <dd className="text-sm text-neutral-700">{formatDate(summary.next_action_at)}</dd>
+              </div>
+              <div>
+                <dt className="text-xs uppercase tracking-wide text-neutral-500">Promesa</dt>
+                <dd className="text-sm text-neutral-700">{formatDate(summary.promise_date)}</dd>
+              </div>
+              <div>
+                <dt className="text-xs uppercase tracking-wide text-neutral-500">Estatus solicitud</dt>
+                <dd className="text-sm text-neutral-700 capitalize">{summary.request_status}</dd>
+              </div>
+            </dl>
+          </div>
+          <TimelineNextSteps status={summary.request_status} nextSteps={nextSteps} />
+        </section>
+
+        <section className="grid gap-6 lg:grid-cols-3">
+          <div className="space-y-6 lg:col-span-2">
+            <CaseUpdateForm
+              caseId={caseId}
+              initialValues={{
+                status: summary.status,
+                next_action_at: summary.next_action_at ?? "",
+                promise_date: summary.promise_date ?? "",
+                promise_amount: summary.promise_amount ?? "",
+                notes: summary.notes ?? "",
+              }}
+            />
+
+            <CaseMessageForm caseId={caseId} requestId={summary.request_id} />
+
+            <CaseActionForm caseId={caseId} />
+          </div>
+
+          <aside className="rounded-lg border border-neutral-200 bg-white p-5 shadow-sm">
+            <h2 className="text-lg font-semibold text-neutral-900">Acciones registradas</h2>
+            {actions.length === 0 ? (
+              <p className="mt-4 text-sm text-neutral-500">Todavía no hay acciones registradas.</p>
+            ) : (
+              <ul className="mt-4 space-y-3 text-sm text-neutral-700">
+                {actions.map((action) => (
+                  <li key={action.id} className="rounded-md border border-neutral-100 bg-neutral-50 p-3">
+                    <p className="font-medium text-neutral-900">{action.action_type}</p>
+                    {action.note ? <p className="text-sm text-neutral-600">{action.note}</p> : null}
+                    <div className="mt-2 text-xs text-neutral-500">
+                      <span>Creada: {formatDate(action.created_at)}</span>
+                      {action.due_at ? <span className="block">Vence: {formatDate(action.due_at)}</span> : null}
+                      {action.completed_at ? <span className="block">Completada: {formatDate(action.completed_at)}</span> : null}
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </aside>
+        </section>
+
+        <section className="space-y-4">
+          <h2 className="text-lg font-semibold text-neutral-900">Historial completo</h2>
+          <TimelineFeed items={timeline} />
+        </section>
+
+        <TimelineRealtimeBridge requestId={summary.request_id} />
+      </div>
+    </div>
+  );
+}
+

--- a/src/app/hq/collections/[caseId]/ui/CaseActionForm.tsx
+++ b/src/app/hq/collections/[caseId]/ui/CaseActionForm.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+
+type Props = {
+  caseId: string;
+};
+
+export function CaseActionForm({ caseId }: Props) {
+  const router = useRouter();
+  const [actionType, setActionType] = useState("");
+  const [note, setNote] = useState("");
+  const [dueAt, setDueAt] = useState("");
+  const [completedAt, setCompletedAt] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!actionType.trim()) {
+      toast.warning("Indica el tipo de acción");
+      return;
+    }
+
+    try {
+      setLoading(true);
+      const response = await fetch(`/api/collections/${caseId}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          kind: "action",
+          actionType,
+          note,
+          dueAt: dueAt || null,
+          completedAt: completedAt || null,
+        }),
+      });
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({ error: "Error" }));
+        throw new Error(data.error || "No se pudo registrar la acción");
+      }
+
+      toast.success("Acción registrada");
+      setActionType("");
+      setNote("");
+      setDueAt("");
+      setCompletedAt("");
+      router.refresh();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Error inesperado";
+      toast.error(message);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="rounded-lg border border-neutral-200 bg-white p-5 shadow-sm">
+      <h2 className="text-lg font-semibold text-neutral-900">Registrar acción</h2>
+      <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <label className="text-sm">
+          <span className="mb-1 block text-xs uppercase tracking-wide text-neutral-500">Tipo</span>
+          <Input value={actionType} onChange={(event) => setActionType(event.target.value)} disabled={loading} />
+        </label>
+        <label className="text-sm">
+          <span className="mb-1 block text-xs uppercase tracking-wide text-neutral-500">Fecha recordatorio</span>
+          <Input type="datetime-local" value={dueAt} onChange={(event) => setDueAt(event.target.value)} disabled={loading} />
+        </label>
+        <label className="text-sm">
+          <span className="mb-1 block text-xs uppercase tracking-wide text-neutral-500">Fecha completado</span>
+          <Input type="datetime-local" value={completedAt} onChange={(event) => setCompletedAt(event.target.value)} disabled={loading} />
+        </label>
+      </div>
+      <label className="mt-4 block text-sm">
+        <span className="mb-1 block text-xs uppercase tracking-wide text-neutral-500">Notas</span>
+        <Textarea value={note} onChange={(event) => setNote(event.target.value)} rows={3} disabled={loading} />
+      </label>
+      <div className="mt-4 flex justify-end">
+        <Button type="submit" disabled={loading}>
+          {loading ? "Guardando..." : "Registrar"}
+        </Button>
+      </div>
+    </form>
+  );
+}
+

--- a/src/app/hq/collections/[caseId]/ui/CaseMessageForm.tsx
+++ b/src/app/hq/collections/[caseId]/ui/CaseMessageForm.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+
+type Props = {
+  caseId: string;
+  requestId: string;
+};
+
+export function CaseMessageForm({ caseId, requestId }: Props) {
+  const router = useRouter();
+  const [subject, setSubject] = useState("");
+  const [message, setMessage] = useState("");
+  const [visibility, setVisibility] = useState<"client" | "internal">("client");
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!message.trim()) {
+      toast.warning("Escribe un mensaje");
+      return;
+    }
+
+    try {
+      setLoading(true);
+      const response = await fetch(`/api/collections/${caseId}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          kind: "message",
+          subject: subject || null,
+          message,
+          visibility,
+        }),
+      });
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({ error: "Error" }));
+        throw new Error(data.error || "No se pudo enviar el mensaje");
+      }
+
+      toast.success(visibility === "client" ? "Mensaje enviado al cliente" : "Nota interna registrada");
+      setSubject("");
+      setMessage("");
+      router.refresh();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Error inesperado";
+      toast.error(message);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="rounded-lg border border-neutral-200 bg-white p-5 shadow-sm">
+      <h2 className="text-lg font-semibold text-neutral-900">Enviar mensaje</h2>
+      <p className="mt-1 text-xs text-neutral-500">
+        El mensaje se asociará al historial de la solicitud <span className="font-mono">{requestId.slice(0, 8)}</span>.
+      </p>
+      <div className="mt-3 flex gap-3 text-xs">
+        <button
+          type="button"
+          onClick={() => setVisibility("client")}
+          className={`rounded-md border px-2 py-1 font-medium ${
+            visibility === "client" ? "border-lp-primary-1 bg-lp-primary-1/10 text-lp-primary-1" : "border-neutral-200 text-neutral-500"
+          }`}
+        >
+          Cliente
+        </button>
+        <button
+          type="button"
+          onClick={() => setVisibility("internal")}
+          className={`rounded-md border px-2 py-1 font-medium ${
+            visibility === "internal"
+              ? "border-neutral-900 bg-neutral-900/10 text-neutral-900"
+              : "border-neutral-200 text-neutral-500"
+          }`}
+        >
+          Interno
+        </button>
+      </div>
+      <div className="mt-4 space-y-3">
+        <Input
+          placeholder="Asunto (opcional)"
+          value={subject}
+          onChange={(event) => setSubject(event.target.value)}
+          disabled={loading}
+        />
+        <Textarea
+          placeholder="Escribe tu mensaje"
+          rows={4}
+          value={message}
+          onChange={(event) => setMessage(event.target.value)}
+          disabled={loading}
+        />
+      </div>
+      <div className="mt-4 flex justify-end">
+        <Button type="submit" disabled={loading}>
+          {loading ? "Enviando..." : "Registrar"}
+        </Button>
+      </div>
+    </form>
+  );
+}
+

--- a/src/app/hq/collections/[caseId]/ui/CaseUpdateForm.tsx
+++ b/src/app/hq/collections/[caseId]/ui/CaseUpdateForm.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+
+const STATUS_OPTIONS: Array<{ value: string; label: string }> = [
+  { value: "open", label: "Abierto" },
+  { value: "in_follow_up", label: "Seguimiento" },
+  { value: "promised", label: "Promesa" },
+  { value: "closed", label: "Cerrado" },
+];
+
+type Props = {
+  caseId: string;
+  initialValues: {
+    status: string;
+    next_action_at: string;
+    promise_date: string;
+    promise_amount: string | number;
+    notes: string;
+  };
+};
+
+export function CaseUpdateForm({ caseId, initialValues }: Props) {
+  const router = useRouter();
+  const [status, setStatus] = useState(initialValues.status || "open");
+  const [nextActionAt, setNextActionAt] = useState(initialValues.next_action_at);
+  const [promiseDate, setPromiseDate] = useState(initialValues.promise_date);
+  const [promiseAmount, setPromiseAmount] = useState(String(initialValues.promise_amount ?? ""));
+  const [notes, setNotes] = useState(initialValues.notes);
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    try {
+      setLoading(true);
+      const response = await fetch(`/api/collections/${caseId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          status,
+          next_action_at: nextActionAt || null,
+          promise_date: promiseDate || null,
+          promise_amount: promiseAmount ? Number(promiseAmount) : null,
+          notes: notes || null,
+        }),
+      });
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({ error: "Error" }));
+        throw new Error(data.error || "No se pudo actualizar el caso");
+      }
+
+      toast.success("Caso actualizado");
+      router.refresh();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Error inesperado";
+      toast.error(message);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="rounded-lg border border-neutral-200 bg-white p-5 shadow-sm">
+      <h2 className="text-lg font-semibold text-neutral-900">Actualizar estatus</h2>
+      <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <label className="text-sm">
+          <span className="mb-1 block text-xs uppercase tracking-wide text-neutral-500">Estatus</span>
+          <select
+            value={status}
+            onChange={(event) => setStatus(event.target.value)}
+            className="w-full rounded-md border border-neutral-200 px-3 py-2 text-sm focus:border-lp-primary-1 focus:outline-none"
+            disabled={loading}
+          >
+            {STATUS_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="text-sm">
+          <span className="mb-1 block text-xs uppercase tracking-wide text-neutral-500">Próxima acción</span>
+          <Input
+            type="datetime-local"
+            value={nextActionAt}
+            onChange={(event) => setNextActionAt(event.target.value)}
+            disabled={loading}
+          />
+        </label>
+        <label className="text-sm">
+          <span className="mb-1 block text-xs uppercase tracking-wide text-neutral-500">Fecha promesa</span>
+          <Input type="date" value={promiseDate} onChange={(event) => setPromiseDate(event.target.value)} disabled={loading} />
+        </label>
+        <label className="text-sm">
+          <span className="mb-1 block text-xs uppercase tracking-wide text-neutral-500">Monto promesa</span>
+          <Input
+            type="number"
+            min="0"
+            step="10000"
+            value={promiseAmount}
+            onChange={(event) => setPromiseAmount(event.target.value)}
+            disabled={loading}
+          />
+        </label>
+      </div>
+      <label className="mt-4 block text-sm">
+        <span className="mb-1 block text-xs uppercase tracking-wide text-neutral-500">Notas internas</span>
+        <Textarea value={notes} onChange={(event) => setNotes(event.target.value)} rows={4} disabled={loading} />
+      </label>
+      <div className="mt-4 flex justify-end">
+        <Button type="submit" disabled={loading}>
+          {loading ? "Guardando..." : "Guardar cambios"}
+        </Button>
+      </div>
+    </form>
+  );
+}
+

--- a/src/app/hq/collections/page.tsx
+++ b/src/app/hq/collections/page.tsx
@@ -1,0 +1,123 @@
+import Link from "next/link";
+
+import { supabaseServer } from "@/lib/supabase-server";
+import { supabaseAdmin } from "@/lib/supabase";
+import { isBackofficeAllowed } from "@/lib/hq-auth";
+import type { CollectionCaseSummary } from "@/lib/request-timeline";
+
+export const dynamic = "force-dynamic";
+
+function formatDate(value: string | null | undefined, withTime = false) {
+  if (!value) return "-";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  const options: Intl.DateTimeFormatOptions = withTime
+    ? { dateStyle: "medium", timeStyle: "short" }
+    : { dateStyle: "medium" };
+  return new Intl.DateTimeFormat("es-CO", options).format(date);
+}
+
+function formatCurrency(value: number | string | null | undefined) {
+  if (value === null || value === undefined) return "-";
+  const amount = typeof value === "string" ? Number(value) : value;
+  if (!Number.isFinite(amount)) return String(value);
+  return new Intl.NumberFormat("es-CO", { style: "currency", currency: "COP", maximumFractionDigits: 0 }).format(amount);
+}
+
+export default async function CollectionsPage() {
+  const supabase = await supabaseServer();
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  const allowed = session ? await isBackofficeAllowed(session.user?.id, session.user?.email) : false;
+
+  if (!allowed) {
+    return (
+      <div className="py-10">
+        <div className="container mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
+          <div className="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+            No tienes permiso para ver esta sección.
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const { data: cases, error } = await supabaseAdmin
+    .from("collection_case_summaries")
+    .select(
+      "id, request_id, company_id, company_name, status, priority, opened_at, next_action_at, promise_date, promise_amount, actions_count, request_status"
+    )
+    .order("opened_at", { ascending: false })
+    .limit(40);
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  const items = (cases ?? []) as CollectionCaseSummary[];
+
+  return (
+    <div className="py-10">
+      <div className="container mx-auto max-w-6xl space-y-6 px-4 sm:px-6 lg:px-8">
+        <header>
+          <h1 className="font-colette text-3xl font-bold text-lp-primary-1">Casos de cobranza</h1>
+          <p className="mt-2 text-sm text-neutral-600">
+            Gestiona recordatorios, compromisos de pago y el cierre de las operaciones en seguimiento.
+          </p>
+        </header>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          {items.length === 0 ? (
+            <div className="col-span-full rounded-lg border border-dashed border-neutral-200 bg-white p-6 text-center text-sm text-neutral-500">
+              No hay casos de cobranza activos.
+            </div>
+          ) : (
+            items.map((item) => (
+              <article key={item.id} className="flex h-full flex-col justify-between rounded-lg border border-neutral-200 bg-white p-5 shadow-sm">
+                <div className="space-y-2">
+                  <div className="flex items-center justify-between text-xs uppercase tracking-wide text-neutral-500">
+                    <span>#{item.request_id.slice(0, 8)}</span>
+                    <span className="rounded-full bg-neutral-100 px-2 py-1 text-[11px] font-medium text-neutral-700">
+                      {item.status}
+                    </span>
+                  </div>
+                  <h2 className="text-base font-semibold text-neutral-900">{item.company_name || item.company_id}</h2>
+                  <dl className="grid grid-cols-2 gap-3 text-sm text-neutral-600">
+                    <div>
+                      <dt className="text-xs text-neutral-400">Próxima acción</dt>
+                      <dd>{formatDate(item.next_action_at, true)}</dd>
+                    </div>
+                    <div>
+                      <dt className="text-xs text-neutral-400">Promesa de pago</dt>
+                      <dd>{formatDate(item.promise_date)}</dd>
+                    </div>
+                    <div>
+                      <dt className="text-xs text-neutral-400">Monto</dt>
+                      <dd>{formatCurrency(item.promise_amount)}</dd>
+                    </div>
+                    <div>
+                      <dt className="text-xs text-neutral-400">Acciones</dt>
+                      <dd>{item.actions_count ?? 0}</dd>
+                    </div>
+                  </dl>
+                </div>
+                <div className="mt-4 flex items-center justify-between text-sm">
+                  <span className="text-neutral-500">Solicitud {item.request_status}</span>
+                  <Link
+                    href={`/hq/collections/${item.id}`}
+                    className="inline-flex items-center rounded-md border border-lp-primary-1 px-3 py-1.5 text-sm font-medium text-lp-primary-1 transition-colors hover:bg-lp-primary-1/10"
+                  >
+                    Ver detalle
+                  </Link>
+                </div>
+              </article>
+            ))
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/app/timeline/TimelineComposer.tsx
+++ b/src/components/app/timeline/TimelineComposer.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+
+type Props = {
+  requestId: string;
+  disabled?: boolean;
+};
+
+export function TimelineComposer({ requestId, disabled }: Props) {
+  const router = useRouter();
+  const [message, setMessage] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!message.trim()) {
+      toast.warning("Escribe un mensaje para continuar");
+      return;
+    }
+
+    try {
+      setSubmitting(true);
+      const response = await fetch(`/api/requests/${requestId}/timeline`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ message }),
+      });
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({ error: "Error" }));
+        throw new Error(data.error || "No pudimos enviar el mensaje");
+      }
+
+      setMessage("");
+      toast.success("Mensaje enviado");
+      router.refresh();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "No se pudo enviar";
+      toast.error(message);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="rounded-lg border border-neutral-200 bg-white p-4 shadow-sm">
+      <h3 className="text-sm font-semibold text-neutral-900">Comparte una actualización</h3>
+      <p className="mt-1 text-xs text-neutral-500">
+        Este mensaje será enviado al equipo de soporte y quedará registrado en el historial.
+      </p>
+      <Textarea
+        value={message}
+        onChange={(event) => setMessage(event.target.value)}
+        placeholder="Escribe tu mensaje"
+        className="mt-3"
+        rows={4}
+        disabled={submitting || disabled}
+      />
+      <div className="mt-3 flex justify-end">
+        <Button type="submit" disabled={submitting || disabled}>
+          {submitting ? "Enviando..." : "Enviar mensaje"}
+        </Button>
+      </div>
+    </form>
+  );
+}
+

--- a/src/components/app/timeline/TimelineFeed.tsx
+++ b/src/components/app/timeline/TimelineFeed.tsx
@@ -1,0 +1,72 @@
+import { CalendarClock, MessageCircle } from "lucide-react";
+
+import type { RequestTimelineItem } from "@/lib/request-timeline";
+import { cn } from "@/lib/utils";
+
+function formatDate(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return new Intl.DateTimeFormat("es-CO", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(date);
+}
+
+const iconByKind = {
+  event: CalendarClock,
+  message: MessageCircle,
+} as const;
+
+export function TimelineFeed({ items }: { items: RequestTimelineItem[] }) {
+  if (!items.length) {
+    return (
+      <div className="rounded-lg border border-dashed border-neutral-200 bg-white p-6 text-center text-sm text-neutral-500">
+        Aún no hay actividad registrada en esta solicitud.
+      </div>
+    );
+  }
+
+  return (
+    <ol className="space-y-4">
+      {items.map((item) => {
+        const Icon = iconByKind[item.item_kind] ?? CalendarClock;
+        return (
+          <li key={`${item.item_kind}-${item.id}`} className="flex gap-3">
+            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-lp-primary-1/10 text-lp-primary-1">
+              <Icon className="h-5 w-5" />
+            </div>
+            <div className="flex-1 rounded-lg border border-neutral-200 bg-white p-4 shadow-sm">
+              <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <p className="font-medium text-neutral-900">{item.title || (item.item_kind === "message" ? "Mensaje" : "Evento")}</p>
+                  {item.actor_name ? (
+                    <p className="text-xs text-neutral-500">{item.actor_name}</p>
+                  ) : item.actor_role ? (
+                    <p className="text-xs text-neutral-500 capitalize">{item.actor_role}</p>
+                  ) : null}
+                </div>
+                <span className="text-xs text-neutral-400">{formatDate(item.occurred_at)}</span>
+              </div>
+              {item.description ? (
+                <p
+                  className={cn(
+                    "mt-3 whitespace-pre-line text-sm text-neutral-700",
+                    item.item_kind === "message" && "text-neutral-800",
+                  )}
+                >
+                  {item.description}
+                </p>
+              ) : null}
+              {item.metadata && Object.keys(item.metadata).length ? (
+                <pre className="mt-3 overflow-x-auto rounded-md bg-neutral-50 p-3 text-xs text-neutral-500">
+                  {JSON.stringify(item.metadata, null, 2)}
+                </pre>
+              ) : null}
+            </div>
+          </li>
+        );
+      })}
+    </ol>
+  );
+}
+

--- a/src/components/app/timeline/TimelineNextSteps.tsx
+++ b/src/components/app/timeline/TimelineNextSteps.tsx
@@ -1,0 +1,29 @@
+import { StatusBadge } from "@/components/ui/status-badge";
+
+export type NextSteps = {
+  label: string;
+  hint?: string | null;
+} | null;
+
+type Props = {
+  status: string | null;
+  nextSteps: NextSteps;
+};
+
+export function TimelineNextSteps({ status, nextSteps }: Props) {
+  if (!nextSteps) return null;
+
+  return (
+    <div className="rounded-lg border border-neutral-200 bg-white p-4 shadow-sm">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <p className="text-sm font-semibold text-neutral-900">Próximo paso</p>
+          <p className="text-base font-medium text-lp-primary-1">{nextSteps.label}</p>
+          {nextSteps.hint ? <p className="text-sm text-neutral-500">{nextSteps.hint}</p> : null}
+        </div>
+        <StatusBadge status={status} kind="request" />
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/app/timeline/TimelineRealtimeBridge.tsx
+++ b/src/components/app/timeline/TimelineRealtimeBridge.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+
+import { subscribeToRequestTimeline } from "@/lib/request-timeline";
+
+type Props = {
+  requestId: string;
+};
+
+export function TimelineRealtimeBridge({ requestId }: Props) {
+  const router = useRouter();
+
+  useEffect(() => {
+    const unsubscribe = subscribeToRequestTimeline(requestId, () => {
+      router.refresh();
+    });
+    return () => {
+      unsubscribe?.();
+    };
+  }, [requestId, router]);
+
+  return null;
+}
+

--- a/src/lib/collections.ts
+++ b/src/lib/collections.ts
@@ -1,0 +1,119 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import { supabaseAdmin } from "@/lib/supabase";
+
+export type CollectionActionRow = {
+  id: string;
+  case_id: string;
+  request_id: string;
+  company_id: string;
+  action_type: string;
+  note: string | null;
+  due_at: string | null;
+  completed_at: string | null;
+  created_by: string | null;
+  created_by_name: string | null;
+  metadata: Record<string, unknown> | null;
+  created_at: string;
+};
+
+export type CollectionCaseRow = {
+  id: string;
+  request_id: string;
+  company_id: string;
+  status: string;
+  priority: string | null;
+  assigned_to: string | null;
+  notes: string | null;
+  opened_at: string;
+  closed_at: string | null;
+  next_action_at: string | null;
+  promise_amount: number | string | null;
+  promise_date: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export async function listCollectionActions(
+  client: SupabaseClient,
+  caseId: string,
+): Promise<CollectionActionRow[]> {
+  const { data, error } = await client
+    .from("collection_actions")
+    .select("*")
+    .eq("case_id", caseId)
+    .order("created_at", { ascending: true });
+
+  if (error) throw error;
+  return (data ?? []) as CollectionActionRow[];
+}
+
+export async function getCollectionCase(
+  client: SupabaseClient,
+  caseId: string,
+): Promise<CollectionCaseRow | null> {
+  const { data, error } = await client
+    .from("collection_cases")
+    .select("*")
+    .eq("id", caseId)
+    .maybeSingle();
+
+  if (error) throw error;
+  return (data as CollectionCaseRow) ?? null;
+}
+
+export async function updateCollectionCase(
+  caseId: string,
+  updates: Partial<Pick<CollectionCaseRow, "status" | "priority" | "assigned_to" | "notes" | "closed_at" | "next_action_at" | "promise_amount" | "promise_date">>,
+) {
+  const payload = {
+    ...updates,
+    updated_at: new Date().toISOString(),
+  };
+
+  const { data, error } = await supabaseAdmin
+    .from("collection_cases")
+    .update(payload)
+    .eq("id", caseId)
+    .select()
+    .maybeSingle();
+
+  if (error) throw error;
+  return data as CollectionCaseRow | null;
+}
+
+export async function createCollectionAction(input: {
+  caseId: string;
+  requestId: string;
+  companyId: string;
+  actionType: string;
+  note?: string | null;
+  dueAt?: string | null;
+  completedAt?: string | null;
+  createdBy?: string | null;
+  createdByName?: string | null;
+  metadata?: Record<string, unknown> | null;
+}) {
+  const payload = {
+    case_id: input.caseId,
+    request_id: input.requestId,
+    company_id: input.companyId,
+    action_type: input.actionType,
+    note: input.note ?? null,
+    due_at: input.dueAt ?? null,
+    completed_at: input.completedAt ?? null,
+    created_by: input.createdBy ?? null,
+    created_by_name: input.createdByName ?? null,
+    metadata: input.metadata ?? null,
+  };
+
+  const { data, error } = await supabaseAdmin
+    .from("collection_actions")
+    .insert(payload)
+    .select()
+    .single();
+
+  if (error) throw error;
+  return data as CollectionActionRow;
+}
+

--- a/src/lib/request-timeline.ts
+++ b/src/lib/request-timeline.ts
@@ -1,0 +1,274 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import { getSupabaseBrowserClient } from "@/lib/supabase-browser";
+import { supabaseAdmin } from "@/lib/supabase";
+
+export type TimelineItemKind = "event" | "message";
+
+export type RequestTimelineItem = {
+  id: string;
+  request_id: string;
+  company_id: string;
+  item_kind: TimelineItemKind;
+  event_type: string | null;
+  status: string | null;
+  title: string | null;
+  description: string | null;
+  actor_role: string | null;
+  actor_id: string | null;
+  actor_name: string | null;
+  metadata: Record<string, unknown> | null;
+  occurred_at: string;
+  created_at: string;
+};
+
+export type RequestMessageInput = {
+  requestId: string;
+  companyId: string;
+  body: string;
+  subject?: string | null;
+  visibility?: "client" | "internal" | "staff";
+  messageType?: string | null;
+  senderId?: string | null;
+  senderRole?: string | null;
+  senderName?: string | null;
+  metadata?: Record<string, unknown> | null;
+};
+
+export type RequestEventInput = {
+  requestId: string;
+  companyId: string;
+  eventType: string;
+  status?: string | null;
+  title?: string | null;
+  description?: string | null;
+  actorRole?: string | null;
+  actorId?: string | null;
+  actorName?: string | null;
+  occurredAt?: string | null;
+  metadata?: Record<string, unknown> | null;
+};
+
+function mapTimelineRow(row: Record<string, unknown>): RequestTimelineItem {
+  return {
+    id: String(row.id ?? ""),
+    request_id: String(row.request_id ?? ""),
+    company_id: String(row.company_id ?? ""),
+    item_kind: (row.item_kind === "message" ? "message" : "event") as TimelineItemKind,
+    event_type: typeof row.event_type === "string" ? row.event_type : null,
+    status: typeof row.status === "string" ? row.status : null,
+    title: typeof row.title === "string" ? row.title : null,
+    description: typeof row.description === "string" ? row.description : null,
+    actor_role: typeof row.actor_role === "string" ? row.actor_role : null,
+    actor_id: typeof row.actor_id === "string" ? row.actor_id : null,
+    actor_name: typeof row.actor_name === "string" ? row.actor_name : null,
+    metadata: (row.metadata && typeof row.metadata === "object") ? (row.metadata as Record<string, unknown>) : null,
+    occurred_at: typeof row.occurred_at === "string" ? row.occurred_at : new Date().toISOString(),
+    created_at: typeof row.created_at === "string" ? row.created_at : new Date().toISOString(),
+  };
+}
+
+export async function getRequestTimeline(
+  client: SupabaseClient,
+  requestId: string,
+): Promise<RequestTimelineItem[]> {
+  const { data, error } = await client
+    .from("request_timeline_entries")
+    .select("*")
+    .eq("request_id", requestId)
+    .order("occurred_at", { ascending: true });
+
+  if (error) throw error;
+  return (data ?? []).map((row) => mapTimelineRow(row as Record<string, unknown>));
+}
+
+export async function createRequestMessage(
+  client: SupabaseClient,
+  input: RequestMessageInput,
+) {
+  const payload = {
+    request_id: input.requestId,
+    company_id: input.companyId,
+    body: input.body,
+    subject: input.subject ?? null,
+    visibility: input.visibility ?? "client",
+    message_type: input.messageType ?? "note",
+    sender_id: input.senderId ?? null,
+    sender_role: input.senderRole ?? null,
+    sender_name: input.senderName ?? null,
+    metadata: input.metadata ?? null,
+  };
+
+  const { data, error } = await client
+    .from("request_messages")
+    .insert(payload)
+    .select()
+    .single();
+
+  if (error) throw error;
+  return data;
+}
+
+export async function createRequestMessageAdmin(input: RequestMessageInput) {
+  return createRequestMessage(supabaseAdmin, input);
+}
+
+export async function createRequestEvent(input: RequestEventInput) {
+  const payload = {
+    request_id: input.requestId,
+    company_id: input.companyId,
+    event_type: input.eventType,
+    status: input.status ?? null,
+    title: input.title ?? null,
+    description: input.description ?? null,
+    actor_role: input.actorRole ?? null,
+    actor_id: input.actorId ?? null,
+    actor_name: input.actorName ?? null,
+    metadata: input.metadata ?? null,
+    occurred_at: input.occurredAt ?? null,
+  };
+
+  const { data, error } = await supabaseAdmin
+    .from("request_events")
+    .insert(payload)
+    .select()
+    .single();
+
+  if (error) throw error;
+  return data;
+}
+
+export type CollectionCaseSummary = {
+  id: string;
+  request_id: string;
+  company_id: string;
+  status: string;
+  priority: string | null;
+  assigned_to: string | null;
+  notes: string | null;
+  opened_at: string;
+  closed_at: string | null;
+  next_action_at: string | null;
+  promise_amount: string | number | null;
+  promise_date: string | null;
+  created_at: string;
+  updated_at: string;
+  request_status: string | null;
+  requested_amount: number | string | null;
+  currency: string | null;
+  company_name: string | null;
+  actions_count: number | null;
+  last_action_id: string | null;
+  last_action_type: string | null;
+  last_action_note: string | null;
+  last_action_due_at: string | null;
+  last_action_completed_at: string | null;
+  last_action_created_at: string | null;
+};
+
+export async function getCollectionCaseSummary(
+  client: SupabaseClient,
+  caseId: string,
+): Promise<CollectionCaseSummary | null> {
+  const { data, error } = await client
+    .from("collection_case_summaries")
+    .select("*")
+    .eq("id", caseId)
+    .maybeSingle();
+
+  if (error) throw error;
+  return data as CollectionCaseSummary | null;
+}
+
+export function subscribeToRequestTimeline(
+  requestId: string,
+  onChange?: () => void,
+) {
+  if (typeof window === "undefined") return () => {};
+
+  try {
+    const client = getSupabaseBrowserClient();
+    const channel = client
+      .channel(`request-timeline:${requestId}`)
+      .on(
+        "postgres_changes",
+        {
+          event: "*",
+          schema: "public",
+          table: "request_timeline_entries",
+          filter: `request_id=eq.${requestId}`,
+        },
+        () => {
+          if (onChange) onChange();
+        },
+      )
+      .subscribe();
+
+    return () => {
+      void client.removeChannel(channel);
+    };
+  } catch (err) {
+    console.error("subscribeToRequestTimeline error", err);
+    return () => {};
+  }
+}
+
+export function computeClientNextSteps(
+  requestStatus: string | null | undefined,
+  collectionCase: Pick<CollectionCaseSummary, "status" | "next_action_at" | "promise_amount" | "promise_date"> | null,
+) {
+  const status = (requestStatus || "").toLowerCase();
+  if (collectionCase && collectionCase.status && collectionCase.status.toLowerCase() !== "closed") {
+    const promiseInfo = collectionCase.promise_date
+      ? `Compromiso de pago para ${new Date(collectionCase.promise_date).toLocaleDateString("es-CO")}`
+      : null;
+    const reminder = collectionCase.next_action_at
+      ? `Revisión programada ${new Date(collectionCase.next_action_at).toLocaleString("es-CO")}`
+      : null;
+    return {
+      label: "Seguimiento de cobranza en curso",
+      hint: promiseInfo || reminder || "Nuestro equipo está acompañando el proceso de cobranza.",
+    };
+  }
+
+  if (status === "funded") {
+    return {
+      label: "Solicitud desembolsada",
+      hint: "Tu operación fue desembolsada. Mantente atento a los recordatorios de pago.",
+    };
+  }
+
+  if (status === "signed") {
+    return {
+      label: "Desembolso en proceso",
+      hint: "Estamos gestionando el desembolso de tu operación.",
+    };
+  }
+
+  if (status === "accepted") {
+    return {
+      label: "Firma de contrato",
+      hint: "Revisa y firma el contrato enviado para continuar con el desembolso.",
+    };
+  }
+
+  if (status === "offered") {
+    return {
+      label: "Aceptar oferta",
+      hint: "Revisa las condiciones para continuar con tu solicitud.",
+    };
+  }
+
+  if (status === "cancelled") {
+    return {
+      label: "Solicitud cancelada",
+      hint: "Contáctanos si deseas retomar el proceso.",
+    };
+  }
+
+  return {
+    label: "Solicitud en revisión",
+    hint: "Nuestro equipo está analizando la información enviada.",
+  };
+}
+

--- a/supabase/migrations/20250212_add_request_timeline.sql
+++ b/supabase/migrations/20250212_add_request_timeline.sql
@@ -1,0 +1,163 @@
+-- Migration: add request timeline, messages, and collections tracking
+
+create table if not exists public.request_events (
+  id uuid primary key default gen_random_uuid(),
+  request_id uuid not null references public.funding_requests(id) on delete cascade,
+  company_id uuid not null references public.companies(id) on delete cascade,
+  event_type text not null,
+  status text,
+  title text,
+  description text,
+  actor_role text,
+  actor_id uuid,
+  actor_name text,
+  metadata jsonb,
+  occurred_at timestamptz not null default timezone('utc', now()),
+  created_at timestamptz not null default timezone('utc', now())
+);
+
+create index if not exists request_events_request_id_idx on public.request_events(request_id, occurred_at desc);
+create index if not exists request_events_company_idx on public.request_events(company_id);
+
+create table if not exists public.request_messages (
+  id uuid primary key default gen_random_uuid(),
+  request_id uuid not null references public.funding_requests(id) on delete cascade,
+  company_id uuid not null references public.companies(id) on delete cascade,
+  sender_id uuid,
+  sender_role text,
+  sender_name text,
+  subject text,
+  body text not null,
+  visibility text not null default 'client',
+  message_type text default 'note',
+  metadata jsonb,
+  sent_at timestamptz not null default timezone('utc', now()),
+  created_at timestamptz not null default timezone('utc', now())
+);
+
+create index if not exists request_messages_request_idx on public.request_messages(request_id, sent_at desc);
+create index if not exists request_messages_company_idx on public.request_messages(company_id);
+
+create table if not exists public.collection_cases (
+  id uuid primary key default gen_random_uuid(),
+  request_id uuid not null references public.funding_requests(id) on delete cascade,
+  company_id uuid not null references public.companies(id) on delete cascade,
+  status text not null default 'open',
+  priority text default 'normal',
+  assigned_to uuid,
+  notes text,
+  opened_at timestamptz not null default timezone('utc', now()),
+  closed_at timestamptz,
+  next_action_at timestamptz,
+  promise_amount numeric,
+  promise_date date,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now())
+);
+
+create index if not exists collection_cases_company_idx on public.collection_cases(company_id);
+create index if not exists collection_cases_request_idx on public.collection_cases(request_id);
+create index if not exists collection_cases_status_idx on public.collection_cases(status, next_action_at);
+
+create table if not exists public.collection_actions (
+  id uuid primary key default gen_random_uuid(),
+  case_id uuid not null references public.collection_cases(id) on delete cascade,
+  request_id uuid not null references public.funding_requests(id) on delete cascade,
+  company_id uuid not null references public.companies(id) on delete cascade,
+  action_type text not null,
+  note text,
+  due_at timestamptz,
+  completed_at timestamptz,
+  created_by uuid,
+  created_by_name text,
+  metadata jsonb,
+  created_at timestamptz not null default timezone('utc', now())
+);
+
+create index if not exists collection_actions_case_idx on public.collection_actions(case_id, created_at desc);
+create index if not exists collection_actions_request_idx on public.collection_actions(request_id);
+
+create or replace view public.request_timeline_entries as
+select
+  e.id,
+  e.request_id,
+  e.company_id,
+  'event'::text as item_kind,
+  e.event_type,
+  e.status,
+  e.title,
+  e.description,
+  e.actor_role,
+  e.actor_id,
+  e.actor_name,
+  e.metadata,
+  e.occurred_at,
+  e.created_at
+from public.request_events e
+union all
+select
+  m.id,
+  m.request_id,
+  m.company_id,
+  'message'::text as item_kind,
+  m.message_type as event_type,
+  m.visibility as status,
+  coalesce(m.subject, 'Mensaje') as title,
+  m.body as description,
+  m.sender_role as actor_role,
+  m.sender_id as actor_id,
+  m.sender_name as actor_name,
+  m.metadata,
+  m.sent_at as occurred_at,
+  m.created_at
+from public.request_messages m;
+
+create or replace view public.collection_case_summaries as
+select
+  c.id,
+  c.request_id,
+  c.company_id,
+  c.status,
+  c.priority,
+  c.assigned_to,
+  c.notes,
+  c.opened_at,
+  c.closed_at,
+  c.next_action_at,
+  c.promise_amount,
+  c.promise_date,
+  c.created_at,
+  c.updated_at,
+  r.status as request_status,
+  r.requested_amount,
+  r.currency,
+  comp.name as company_name,
+  ca_total.actions_count,
+  ca_last.last_action_id,
+  ca_last.last_action_type,
+  ca_last.last_action_note,
+  ca_last.last_action_due_at,
+  ca_last.last_action_completed_at,
+  ca_last.last_action_created_at
+from public.collection_cases c
+left join public.funding_requests r on r.id = c.request_id
+left join public.companies comp on comp.id = c.company_id
+left join lateral (
+  select count(*)::bigint as actions_count
+  from public.collection_actions ca
+  where ca.case_id = c.id
+) ca_total on true
+left join lateral (
+  select
+    ca.id as last_action_id,
+    ca.action_type as last_action_type,
+    ca.note as last_action_note,
+    ca.due_at as last_action_due_at,
+    ca.completed_at as last_action_completed_at,
+    ca.created_at as last_action_created_at
+  from public.collection_actions ca
+  where ca.case_id = c.id
+  order by ca.created_at desc
+  limit 1
+) ca_last on true;
+


### PR DESCRIPTION
## Summary
- add Supabase tables, views, and helpers for request timeline events, messages, and collections tracking
- expose REST endpoints to read and update timelines and collections with automatic notifications
- build customer and HQ UIs for timeline visualization, messaging, and collection follow-up actions

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dcefbf3848832f957eaa82b83b8ebb