### PR TITLE
Handle Supabase admin client lazily to avoid missing env crash

### DIFF
--- a/src/app/api/c/[orgId]/invoices/[invoiceId]/file/route.ts
+++ b/src/app/api/c/[orgId]/invoices/[invoiceId]/file/route.ts
@@ -35,7 +35,8 @@ export async function DELETE(
       .single();
     if (rErr || !inv) return NextResponse.json({ ok: false, error: rErr?.message ?? "Not found" }, { status: 404 });
 
-    const { supabaseAdmin } = await import("@/lib/supabase");
+    const { getSupabaseAdminClient } = await import("@/lib/supabase");
+    const supabaseAdmin = getSupabaseAdminClient();
     if (inv.file_path) {
       await supabaseAdmin.storage.from("invoices").remove([inv.file_path]);
     }
@@ -77,7 +78,8 @@ export async function PUT(
       .single();
     if (rErr || !inv) return NextResponse.json({ ok: false, error: rErr?.message ?? "Not found" }, { status: 404 });
 
-    const { supabaseAdmin } = await import("@/lib/supabase");
+    const { getSupabaseAdminClient } = await import("@/lib/supabase");
+    const supabaseAdmin = getSupabaseAdminClient();
     const { error: upErr } = await supabaseAdmin
       .from("invoices")
       .update({ file_path })

--- a/src/app/api/c/[orgId]/invoices/[invoiceId]/route.ts
+++ b/src/app/api/c/[orgId]/invoices/[invoiceId]/route.ts
@@ -30,7 +30,8 @@ export async function DELETE(
       .single();
     if (rErr || !inv) return NextResponse.json({ ok: false, error: rErr?.message ?? "Not found" }, { status: 404 });
 
-    const { supabaseAdmin } = await import("@/lib/supabase");
+    const { getSupabaseAdminClient } = await import("@/lib/supabase");
+    const supabaseAdmin = getSupabaseAdminClient();
     if (inv.file_path) {
       await supabaseAdmin.storage.from("invoices").remove([inv.file_path]);
     }

--- a/src/app/api/c/[orgId]/memberships/route.ts
+++ b/src/app/api/c/[orgId]/memberships/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import { cookies } from "next/headers";
 
-import { supabaseAdmin } from "@/lib/supabase";
+import { getSupabaseAdminClient } from "@/lib/supabase";
 import {
   DEFAULT_MEMBER_ROLE,
   DEFAULT_MEMBER_STATUS,
@@ -88,6 +88,7 @@ async function resolveUserIdFromPayload(payload: Record<string, unknown>) {
     throw new Error("Missing user identifier");
   }
 
+  const supabaseAdmin = getSupabaseAdminClient();
   const adminAuth = (supabaseAdmin.auth as unknown as { admin?: AdminAuthClient }).admin;
   if (!adminAuth || typeof adminAuth.getUserByEmail !== "function") {
     throw new Error("Supabase admin client unavailable");
@@ -119,6 +120,8 @@ export async function GET(
     if (!canRead) {
       return NextResponse.json({ ok: false, error: "Forbidden" }, { status: 403 });
     }
+
+    const supabaseAdmin = getSupabaseAdminClient();
 
     const { data, error } = await supabaseAdmin
       .from("memberships")
@@ -169,6 +172,8 @@ export async function POST(
     } catch {
       return NextResponse.json({ ok: false, error: "Forbidden" }, { status: 403 });
     }
+
+    const supabaseAdmin = getSupabaseAdminClient();
 
     let payload: Record<string, unknown>;
     try {
@@ -268,6 +273,8 @@ export async function PATCH(
     } catch {
       return NextResponse.json({ ok: false, error: "Forbidden" }, { status: 403 });
     }
+
+    const supabaseAdmin = getSupabaseAdminClient();
 
     let payload: Record<string, unknown>;
     try {
@@ -384,6 +391,8 @@ export async function DELETE(
     } catch {
       return NextResponse.json({ ok: false, error: "Forbidden" }, { status: 403 });
     }
+
+    const supabaseAdmin = getSupabaseAdminClient();
 
     const { data: existingRows, error: existingError } = await supabaseAdmin
       .from("memberships")

--- a/src/app/api/c/[orgId]/requests/[requestId]/file/route.ts
+++ b/src/app/api/c/[orgId]/requests/[requestId]/file/route.ts
@@ -1,4 +1,4 @@
-﻿import { NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import { cookies } from "next/headers";
 
@@ -34,7 +34,8 @@ export async function GET(_req: Request, { params }: RouteContext) {
       return NextResponse.json({ ok: false, error: "file_not_found" }, { status: 404 });
     }
 
-    const { supabaseAdmin } = await import("@/lib/supabase");
+    const { getSupabaseAdminClient } = await import("@/lib/supabase");
+    const supabaseAdmin = getSupabaseAdminClient();
     const { data: signed, error: signedErr } = await supabaseAdmin.storage
       .from("requests")
       .createSignedUrl(fr.file_path, 60, { download: true });
@@ -75,7 +76,8 @@ export async function DELETE(_req: Request, { params }: RouteContext) {
       return NextResponse.json({ ok: false, error: message }, { status: 404 });
     }
 
-    const { supabaseAdmin } = await import("@/lib/supabase");
+    const { getSupabaseAdminClient } = await import("@/lib/supabase");
+    const supabaseAdmin = getSupabaseAdminClient();
 
     if (fr.file_path) {
       await supabaseAdmin.storage.from("requests").remove([fr.file_path]);
@@ -130,7 +132,8 @@ export async function PUT(req: Request, { params }: RouteContext) {
       return NextResponse.json({ ok: false, error: message }, { status: 404 });
     }
 
-    const { supabaseAdmin } = await import("@/lib/supabase");
+    const { getSupabaseAdminClient } = await import("@/lib/supabase");
+    const supabaseAdmin = getSupabaseAdminClient();
 
     const { error: upErr } = await supabaseAdmin
       .from("funding_requests")

--- a/src/app/api/c/[orgId]/requests/[requestId]/force-signed/route.ts
+++ b/src/app/api/c/[orgId]/requests/[requestId]/force-signed/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import { cookies } from "next/headers";
-import { supabaseAdmin } from "@/lib/supabase";
+import { getSupabaseAdminClient } from "@/lib/supabase";
 import { logAudit } from "@/lib/audit";
 
 export async function POST(
@@ -19,6 +19,8 @@ export async function POST(
     if (!allowForceSign) {
       return NextResponse.json({ ok: false, error: 'Accion deshabilitada en este ambiente.', code: 'force_sign_disabled' }, { status: 403 });
     }
+
+    const supabaseAdmin = getSupabaseAdminClient();
 
     const { data: doc } = await supabaseAdmin
       .from('documents')

--- a/src/app/api/c/[orgId]/requests/[requestId]/route.ts
+++ b/src/app/api/c/[orgId]/requests/[requestId]/route.ts
@@ -52,7 +52,8 @@ export async function DELETE(
       .single();
     if (rErr || !fr) return NextResponse.json({ ok: false, error: rErr?.message ?? "Not found" }, { status: 404 });
 
-    const { supabaseAdmin } = await import("@/lib/supabase");
+    const { getSupabaseAdminClient } = await import("@/lib/supabase");
+    const supabaseAdmin = getSupabaseAdminClient();
     if (fr.file_path) {
       await supabaseAdmin.storage.from("requests").remove([fr.file_path]);
     }

--- a/src/app/api/c/[orgId]/settings/route.ts
+++ b/src/app/api/c/[orgId]/settings/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import { cookies } from "next/headers";
 
-import { supabaseAdmin } from "@/lib/supabase";
+import { getSupabaseAdminClient } from "@/lib/supabase";
 
 const COMPANY_COLUMNS = "id, name, legal_name, tax_id, contact_email, contact_phone, billing_email, bank_account, notification_email, notification_sms, notification_whatsapp, type, created_at, updated_at";
 const EDITABLE_ROLES = new Set(["OWNER", "ADMIN"]);
@@ -187,6 +187,7 @@ export async function PUT(
 
     update.updated_at = new Date().toISOString();
 
+    const supabaseAdmin = getSupabaseAdminClient();
     const { data: updated, error } = await supabaseAdmin
       .from("companies")
       .update(update)

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -1,7 +1,7 @@
 // src/app/api/contact/route.ts
 export const runtime = "nodejs";
 import { NextResponse } from "next/server";
-import { supabaseAdmin } from "@/lib/supabase";
+import { getSupabaseAdminClient } from "@/lib/supabase";
 
 export async function POST(req: Request) {
   try {
@@ -35,6 +35,7 @@ export async function POST(req: Request) {
     const utm_content  = body.utm_content  ?? qs.get("utm_content");
     const referrer     = body.referrer     ?? req.headers.get("referer");
 
+    const supabaseAdmin = getSupabaseAdminClient();
     const { error } = await supabaseAdmin.from("contacts").insert({
       full_name: nombre,
       email,

--- a/src/app/api/hq/orgs/route.ts
+++ b/src/app/api/hq/orgs/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import { cookies } from "next/headers";
-import { supabaseAdmin } from "@/lib/supabase";
+import { getSupabaseAdminClient } from "@/lib/supabase";
 import { isBackofficeAllowed } from "@/lib/hq-auth";
 
 export async function GET() {
@@ -18,6 +18,8 @@ export async function GET() {
   if (!isAllowed) {
     return NextResponse.json({ ok: false, error: "Unauthorized" }, { status: 401 });
   }
+
+  const supabaseAdmin = getSupabaseAdminClient();
 
   const { data: companies, error } = await supabaseAdmin
     .from('companies')

--- a/src/app/api/orgs/route.ts
+++ b/src/app/api/orgs/route.ts
@@ -51,7 +51,8 @@ export async function POST(req: Request) {
 
     // Ensure profile exists (user may predate trigger) via UPSERT
     {
-      const { supabaseAdmin } = await import("@/lib/supabase");
+      const { getSupabaseAdminClient } = await import("@/lib/supabase");
+      const supabaseAdmin = getSupabaseAdminClient();
       const { error: pErr } = await supabaseAdmin
         .from("profiles")
         .upsert(
@@ -71,7 +72,8 @@ export async function POST(req: Request) {
     }
 
     // Create company and membership
-    const { supabaseAdmin } = await import("@/lib/supabase");
+    const { getSupabaseAdminClient } = await import("@/lib/supabase");
+    const supabaseAdmin = getSupabaseAdminClient();
     const { data: org, error: orgErr } = await supabaseAdmin
       .from("companies")
       .insert({ name, type })

--- a/src/app/hq/collections/[caseId]/page.tsx
+++ b/src/app/hq/collections/[caseId]/page.tsx
@@ -5,7 +5,7 @@ import { TimelineFeed } from "@/components/app/timeline/TimelineFeed";
 import { TimelineRealtimeBridge } from "@/components/app/timeline/TimelineRealtimeBridge";
 import { TimelineNextSteps } from "@/components/app/timeline/TimelineNextSteps";
 import { supabaseServer } from "@/lib/supabase-server";
-import { supabaseAdmin } from "@/lib/supabase";
+import { getSupabaseAdminClient } from "@/lib/supabase";
 import { isBackofficeAllowed } from "@/lib/hq-auth";
 import { listCollectionActions } from "@/lib/collections";
 import { computeClientNextSteps, getCollectionCaseSummary, getRequestTimeline } from "@/lib/request-timeline";
@@ -46,6 +46,8 @@ export default async function CollectionCasePage({
       </div>
     );
   }
+
+  const supabaseAdmin = getSupabaseAdminClient();
 
   const summary = await getCollectionCaseSummary(supabaseAdmin, caseId);
   if (!summary) {

--- a/src/app/hq/collections/page.tsx
+++ b/src/app/hq/collections/page.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 
 import { supabaseServer } from "@/lib/supabase-server";
-import { supabaseAdmin } from "@/lib/supabase";
+import { getSupabaseAdminClient } from "@/lib/supabase";
 import { isBackofficeAllowed } from "@/lib/hq-auth";
 import type { CollectionCaseSummary } from "@/lib/request-timeline";
 
@@ -44,6 +44,7 @@ export default async function CollectionsPage() {
     );
   }
 
+  const supabaseAdmin = getSupabaseAdminClient();
   const { data: cases, error } = await supabaseAdmin
     .from("collection_case_summaries")
     .select(

--- a/src/app/hq/page.tsx
+++ b/src/app/hq/page.tsx
@@ -1,5 +1,5 @@
 import { supabaseServer } from "@/lib/supabase-server";
-import { supabaseAdmin } from "@/lib/supabase";
+import { getSupabaseAdminClient } from "@/lib/supabase";
 import { isBackofficeAllowed } from "@/lib/hq-auth";
 import { RequestsBoard } from "./ui/RequestsBoard";
 import { UsersManager } from "./ui/UsersManager";
@@ -30,6 +30,7 @@ export default async function HqPage() {
   }
 
   // Companies are still needed for the UsersManager dropdown
+  const supabaseAdmin = getSupabaseAdminClient();
   const { data: companies } = await supabaseAdmin
     .from("companies")
     .select("id, name, type")

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -1,4 +1,4 @@
-﻿import { supabaseAdmin } from "@/lib/supabase";
+import { getSupabaseAdminClient } from "@/lib/supabase";
 
 type AuditEntity = 'invoice' | 'request' | 'offer' | 'document' | 'contract' | 'membership' | 'integration' | 'feedback';
 type AuditAction =
@@ -25,6 +25,7 @@ type AuditPayload = {
 
 export async function logAudit(input: AuditPayload) {
   try {
+    const supabaseAdmin = getSupabaseAdminClient();
     await supabaseAdmin.from('audit_logs').insert({
       company_id: input.company_id,
       actor_id: input.actor_id ?? null,

--- a/src/lib/collections.ts
+++ b/src/lib/collections.ts
@@ -1,6 +1,6 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 
-import { supabaseAdmin } from "@/lib/supabase";
+import { getSupabaseAdminClient } from "@/lib/supabase";
 
 export type CollectionActionRow = {
   id: string;
@@ -71,7 +71,7 @@ export async function updateCollectionCase(
     updated_at: new Date().toISOString(),
   };
 
-  const { data, error } = await supabaseAdmin
+  const { data, error } = await getSupabaseAdminClient()
     .from("collection_cases")
     .update(payload)
     .eq("id", caseId)
@@ -107,7 +107,7 @@ export async function createCollectionAction(input: {
     metadata: input.metadata ?? null,
   };
 
-  const { data, error } = await supabaseAdmin
+  const { data, error } = await getSupabaseAdminClient()
     .from("collection_actions")
     .insert(payload)
     .select()

--- a/src/lib/hq-auth.ts
+++ b/src/lib/hq-auth.ts
@@ -1,4 +1,4 @@
-import { supabaseAdmin } from "@/lib/supabase";
+import { getSupabaseAdminClient } from "@/lib/supabase";
 
 export async function isBackofficeAllowed(userId?: string | null, email?: string | null) {
   const allowedList = (process.env.BACKOFFICE_ALLOWED_EMAILS || "")
@@ -27,6 +27,7 @@ export async function isBackofficeAllowed(userId?: string | null, email?: string
 }
 
 async function fetchStaffFlag(userId: string): Promise<boolean> {
+  const supabaseAdmin = getSupabaseAdminClient();
   const { data, error } = await supabaseAdmin
     .from("profiles")
     .select("is_staff")

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -1,5 +1,5 @@
 import { Resend } from "resend";
-import { supabaseAdmin } from "@/lib/supabase";
+import { getSupabaseAdminClient } from "@/lib/supabase";
 import { canManageMembership, normalizeMemberRole } from "@/lib/rbac";
 
 const resendApiKey = process.env.RESEND_API_KEY;
@@ -15,6 +15,7 @@ function staffRecipients(): string[] {
 }
 
 export async function getCompanyActiveMemberEmails(companyId: string): Promise<{ owners: string[]; admins: string[]; clients: string[]; all: string[]; }> {
+  const supabaseAdmin = getSupabaseAdminClient();
   const { data: members, error } = await supabaseAdmin
     .from("memberships")
     .select("user_id, role, status")

--- a/src/lib/request-timeline.ts
+++ b/src/lib/request-timeline.ts
@@ -1,7 +1,7 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 
 import { getSupabaseBrowserClient } from "@/lib/supabase-browser";
-import { supabaseAdmin } from "@/lib/supabase";
+import { getSupabaseAdminClient } from "@/lib/supabase";
 
 export type TimelineItemKind = "event" | "message";
 
@@ -110,10 +110,11 @@ export async function createRequestMessage(
 }
 
 export async function createRequestMessageAdmin(input: RequestMessageInput) {
-  return createRequestMessage(supabaseAdmin, input);
+  return createRequestMessage(getSupabaseAdminClient(), input);
 }
 
 export async function createRequestEvent(input: RequestEventInput) {
+  const supabaseAdmin = getSupabaseAdminClient();
   const payload = {
     request_id: input.requestId,
     company_id: input.companyId,

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,13 +1,35 @@
 // src/lib/supabase.ts
-import { createClient } from "@supabase/supabase-js";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 
-const url = process.env.SUPABASE_URL;
-const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY; // servidor solo
+let cachedClient: SupabaseClient | null = null;
 
-if (!url || !serviceKey) {
-  throw new Error("Missing Supabase environment variables");
+export function getSupabaseAdminClient(): SupabaseClient {
+  if (cachedClient) return cachedClient;
+
+  const url = process.env.SUPABASE_URL;
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY; // servidor solo
+
+  if (!url || !serviceKey) {
+    throw new Error("Missing Supabase environment variables");
+  }
+
+  cachedClient = createClient(url, serviceKey, {
+    auth: { persistSession: false },
+  });
+
+  return cachedClient;
 }
 
-export const supabaseAdmin = createClient(url, serviceKey, {
-  auth: { persistSession: false },
-});
+export const supabaseAdmin = new Proxy(
+  {},
+  {
+    get(_target, prop, receiver) {
+      const client = getSupabaseAdminClient() as unknown as Record<PropertyKey, unknown>;
+      const value = Reflect.get(client, prop, receiver);
+      if (typeof value === "function") {
+        return (value as (...args: unknown[]) => unknown).bind(client);
+      }
+      return value;
+    },
+  },
+) as unknown as SupabaseClient;


### PR DESCRIPTION
## Summary
- add a cached getter for the Supabase admin client and expose a proxy to preserve existing imports
- update server utilities and routes that rely on the admin client to fetch it lazily when needed
- ensure client-only environments no longer throw during module evaluation when service role variables are absent

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e4d11f65f0832f8ca78be23f42913c