### PR TITLE
Fix HQ layout auth guard regression

### DIFF
--- a/src/app/hq/layout.tsx
+++ b/src/app/hq/layout.tsx
@@ -1,0 +1,32 @@
+import { ReactNode } from "react";
+import { Toaster } from "@/components/ui/sonner";
+import { HqNavigation } from "./ui/HqNavigation";
+import { HqAccessGate } from "./ui/HqAccessGate";
+
+export const dynamic = "force-dynamic";
+
+interface HqLayoutProps {
+  children: ReactNode;
+}
+
+export default function HqLayout({ children }: HqLayoutProps) {
+  return (
+    <HqAccessGate>
+      <div className="py-10">
+        <div className="container mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+          <header className="mb-8">
+            <h1 className="font-colette text-3xl font-bold text-lp-primary-1">Backoffice HQ</h1>
+            <p className="mt-2 text-sm text-lp-sec-3">
+              Panel de control con métricas, operaciones y gestión de usuarios.
+            </p>
+          </header>
+
+          <HqNavigation />
+
+          <main className="mt-8 space-y-8">{children}</main>
+        </div>
+        <Toaster position="top-right" richColors />
+      </div>
+    </HqAccessGate>
+  );
+}

--- a/src/app/hq/operaciones/page.tsx
+++ b/src/app/hq/operaciones/page.tsx
@@ -1,0 +1,11 @@
+import { KycQueue } from "../ui/KycQueue";
+import { RequestsBoard } from "../ui/RequestsBoard";
+
+export default function HqOperationsPage() {
+  return (
+    <div className="space-y-8">
+      <KycQueue />
+      <RequestsBoard />
+    </div>
+  );
+}

--- a/src/app/hq/page.tsx
+++ b/src/app/hq/page.tsx
@@ -1,59 +1,9 @@
-import { supabaseServer } from "@/lib/supabase-server";
-import { getSupabaseAdminClient } from "@/lib/supabase";
-import { isBackofficeAllowed } from "@/lib/hq-auth";
-import { RequestsBoard } from "./ui/RequestsBoard";
-import { UsersManager } from "./ui/UsersManager";
 import { DashboardMetrics } from "./ui/DashboardMetrics";
-import { KycQueue } from "./ui/KycQueue";
-import { Toaster } from "@/components/ui/sonner";
 
-export const dynamic = "force-dynamic";
-
-export default async function HqPage() {
-  const supabase = await supabaseServer();
-  const {
-    data: { session },
-  } = await supabase.auth.getSession();
-
-  const isAllowed = session ? await isBackofficeAllowed(session.user?.id, session.user?.email) : false;
-
-  if (!isAllowed) {
-    return (
-      <div className="py-10">
-        <div className="container mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
-          <div className="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-700">
-            No tienes permiso para ver esta página.
-          </div>
-        </div>
-      </div>
-    );
-  }
-
-  // Companies are still needed for the UsersManager dropdown
-  const supabaseAdmin = getSupabaseAdminClient();
-  const { data: companies } = await supabaseAdmin
-    .from("companies")
-    .select("id, name, type")
-    .order("name", { ascending: true });
-
+export default function HqOverviewPage() {
   return (
-    <div className="py-10">
-      <div className="container mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-        <header className="mb-8">
-          <h1 className="font-colette text-3xl font-bold text-lp-primary-1">Backoffice HQ</h1>
-          <p className="mt-2 text-sm text-lp-sec-3">
-            Panel de control con métricas, operaciones y gestión de usuarios.
-          </p>
-        </header>
-
-        <div className="space-y-8">
-          <DashboardMetrics />
-          <KycQueue />
-          <RequestsBoard />
-          <UsersManager companies={companies ?? []} />
-        </div>
-      </div>
-      <Toaster position="top-right" richColors />
+    <div className="space-y-8">
+      <DashboardMetrics />
     </div>
   );
 }

--- a/src/app/hq/ui/HqAccessGate.tsx
+++ b/src/app/hq/ui/HqAccessGate.tsx
@@ -1,0 +1,30 @@
+import { ReactNode } from "react";
+import { supabaseServer } from "@/lib/supabase-server";
+import { isBackofficeAllowed } from "@/lib/hq-auth";
+
+interface HqAccessGateProps {
+  children: ReactNode;
+}
+
+export async function HqAccessGate({ children }: HqAccessGateProps) {
+  const supabase = await supabaseServer();
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  const isAllowed = session ? await isBackofficeAllowed(session.user?.id, session.user?.email) : false;
+
+  if (!isAllowed) {
+    return (
+      <div className="py-10">
+        <div className="container mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+          <div className="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+            No tienes permiso para ver esta página.
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/src/app/hq/ui/HqNavigation.tsx
+++ b/src/app/hq/ui/HqNavigation.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+import { cn } from "@/lib/utils";
+
+const links = [
+  { href: "/hq", label: "Resumen" },
+  { href: "/hq/operaciones", label: "Operaciones" },
+  { href: "/hq/usuarios", label: "Usuarios" },
+];
+
+export function HqNavigation() {
+  const pathname = usePathname();
+
+  return (
+    <nav aria-label="Secciones del HQ" className="border-b border-lp-sec-6">
+      <ul className="-mb-px flex flex-wrap gap-4 text-sm font-medium text-lp-sec-4">
+        {links.map((link) => {
+          const isActive =
+            pathname === link.href || pathname.startsWith(`${link.href}/`);
+
+          return (
+            <li key={link.href}>
+              <Link
+                href={link.href}
+                className={cn(
+                  "inline-flex items-center border-b-2 border-transparent pb-2 transition-colors",
+                  isActive
+                    ? "border-lp-primary-1 text-lp-primary-1"
+                    : "hover:border-lp-sec-5 hover:text-lp-sec-2"
+                )}
+              >
+                {link.label}
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}

--- a/src/app/hq/usuarios/page.tsx
+++ b/src/app/hq/usuarios/page.tsx
@@ -1,0 +1,15 @@
+import { getSupabaseAdminClient } from "@/lib/supabase";
+
+import { UsersManager } from "../ui/UsersManager";
+
+export const dynamic = "force-dynamic";
+
+export default async function HqUsersPage() {
+  const supabaseAdmin = getSupabaseAdminClient();
+  const { data: companies } = await supabaseAdmin
+    .from("companies")
+    .select("id, name, type")
+    .order("name", { ascending: true });
+
+  return <UsersManager companies={companies ?? []} />;
+}


### PR DESCRIPTION
## Summary
- wrap the HQ layout contents in a dedicated access gate component
- reuse the previous permission check in the guard so authorized users can enter again

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e611b26e08832f9582776a0774d632