### PR TITLE
Link contract CTA to PandaDoc document

### DIFF
--- a/src/app/api/c/[orgId]/requests/route.ts
+++ b/src/app/api/c/[orgId]/requests/route.ts
@@ -42,6 +42,7 @@ type ClientNextStep = {
     kind: string;
     label?: string | null;
     offer_id?: string;
+    url?: string | null;
   } | null;
 } | null;
 
@@ -61,11 +62,14 @@ function computeClientNextStep(
   const contractStatus = (contract?.status || "").toLowerCase();
   const contractSigned = contractStatus.includes('signed') || contractStatus.includes('completed');
   const isContractDraftLike = contractStatus.includes('draft') || contractStatus.includes('creating');
-  const contractCTA = !contract || isContractDraftLike
+  const appBase = process.env.PANDADOC_APP_URL || 'https://app.pandadoc.com/a/#/documents/';
+  const contractUrl = contract?.provider_envelope_id ? `${appBase}${contract.provider_envelope_id}` : null;
+  const contractCTA = !contract || isContractDraftLike || !contractUrl
     ? null
     : {
         kind: "open_contract",
         label: contractSigned ? "Ver contrato" : "Firmar contrato",
+        url: contractUrl,
       };
 
   if (normalized === "offered") {

--- a/src/app/c/[orgId]/requests/ui/RequestsClient.tsx
+++ b/src/app/c/[orgId]/requests/ui/RequestsClient.tsx
@@ -52,6 +52,7 @@ type RequestItem = {
       kind: string;
       label?: string | null;
       offer_id?: string;
+      url?: string | null;
     } | null;
   } | null;
 };
@@ -1502,35 +1503,6 @@ function RequestRow({ orgId, req, onChanged, onOpenTimeline }: { orgId: string; 
       setBusy(false);
     }
   };
-  const onOpenContract = async () => {
-    closeMenu();
-    setBusy(true);
-    setErr(null);
-    try {
-      const res = await fetch(`/api/c/${orgId}/requests/${req.id}/contract/link`);
-      const data = (await res.json().catch(() => ({}))) as { ok?: boolean; url?: string; error?: string };
-      if (!res.ok || !data?.ok || typeof data.url !== "string") {
-        const friendly = data?.error === 'contract_not_ready'
-          ? "Aun estamos preparando tu contrato. Te avisaremos en cuanto este listo."
-          : data?.error || "No se pudo abrir el contrato";
-        throw new Error(friendly);
-      }
-      const popup = window.open(data.url, "_blank", "noopener,noreferrer");
-      if (!popup) {
-        window.location.href = data.url;
-      } else {
-        popup.opener = null;
-      }
-      toast.success("Contrato listo para firma");
-    } catch (e: unknown) {
-      const msg = e instanceof Error ? e.message : "Error abriendo contrato";
-      setErr(msg);
-      toast.error(msg);
-    } finally {
-      setBusy(false);
-    }
-  };
-
   const formatCurrencyCOP = (value: number | null | undefined) => {
     if (typeof value !== "number" || Number.isNaN(value)) return "-";
     return new Intl.NumberFormat("es-CO", { style: "currency", currency: "COP", maximumFractionDigits: 0 }).format(value);
@@ -1726,16 +1698,17 @@ function RequestRow({ orgId, req, onChanged, onOpenTimeline }: { orgId: string; 
                 {nextStep.cta.label ?? "Aceptar oferta"}
               </Button>
             ) : null}
-            {nextStep.cta?.kind === "open_contract" ? (
-              <Button
-                type="button"
-                size="sm"
-                variant="default"
-                className="mt-1"
-                onClick={() => void onOpenContract()}
-                disabled={busy}
-              >
-                {contractActionLabel}
+            {nextStep.cta?.kind === "open_contract" && nextStep.cta?.url ? (
+              <Button asChild size="sm" variant="default" className="mt-1">
+                <Link
+                  href={nextStep.cta.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  prefetch={false}
+                  onClick={closeMenu}
+                >
+                  {contractActionLabel}
+                </Link>
               </Button>
             ) : null}
             {err && <p className="text-xs text-red-600">{err}</p>}
@@ -1815,15 +1788,17 @@ function RequestRow({ orgId, req, onChanged, onOpenTimeline }: { orgId: string; 
                             {nextStep.cta.label ?? "Aceptar oferta"}
                           </Button>
                         ) : null}
-                        {nextStep.cta?.kind === "open_contract" ? (
-                          <Button
-                            type="button"
-                            size="sm"
-                            className="mt-3 w-full"
-                            onClick={() => void onOpenContract()}
-                            disabled={busy}
-                          >
-                            {contractActionLabel}
+                        {nextStep.cta?.kind === "open_contract" && nextStep.cta?.url ? (
+                          <Button asChild size="sm" className="mt-3 w-full">
+                            <Link
+                              href={nextStep.cta.url}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              prefetch={false}
+                              onClick={closeMenu}
+                            >
+                              {contractActionLabel}
+                            </Link>
                           </Button>
                         ) : null}
                       </div>


### PR DESCRIPTION
## Summary
- include PandaDoc document URL in the client next-step contract CTA when a contract envelope exists
- render the "Firmar contrato" CTA as an external link to PandaDoc instead of calling the unfinished API session endpoint

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e66cc135fc832f9f50c4585df0129f