### PR TITLE
Separate KYC queue into dedicated page

### DIFF
--- a/src/app/hq/kyc/page.tsx
+++ b/src/app/hq/kyc/page.tsx
@@ -1,0 +1,9 @@
+import { KycQueue } from "../ui/KycQueue";
+
+export default function HqKycPage() {
+  return (
+    <div className="space-y-8">
+      <KycQueue />
+    </div>
+  );
+}

--- a/src/app/hq/operaciones/page.tsx
+++ b/src/app/hq/operaciones/page.tsx
@@ -1,10 +1,8 @@
-import { KycQueue } from "../ui/KycQueue";
 import { RequestsBoard } from "../ui/RequestsBoard";
 
 export default function HqOperationsPage() {
   return (
     <div className="space-y-8">
-      <KycQueue />
       <RequestsBoard />
     </div>
   );

--- a/src/app/hq/ui/HqNavigation.tsx
+++ b/src/app/hq/ui/HqNavigation.tsx
@@ -7,6 +7,7 @@ import { cn } from "@/lib/utils";
 
 const links = [
   { href: "/hq", label: "Resumen" },
+  { href: "/hq/kyc", label: "Verificaciones KYC" },
   { href: "/hq/operaciones", label: "Operaciones" },
   { href: "/hq/usuarios", label: "Usuarios" },
 ];


### PR DESCRIPTION
## Summary
- add a dedicated /hq/kyc page that renders the KYC verification queue on its own
- remove the KYC queue from the operations overview so it only shows active requests
- update the HQ navigation to link to the new KYC section

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e678329a00832f80dc1200568fcd08