### PR TITLE
Stop flagging KYC docs as pending on funded requests

### DIFF
--- a/src/app/api/hq/requests/route.ts
+++ b/src/app/api/hq/requests/route.ts
@@ -428,8 +428,10 @@ function summariseDocuments(requestDocs: DocumentRow[], companyDocs: DocumentRow
     maybeUpdate(doc);
   }
 
-  const missing = REQUIRED_DOC_TYPES.filter((type) => !latestByType.has(type));
+  const missing = REQUIRED_DOC_TYPES.filter((type) => !latestByType.has(type))
+    .filter((type) => !type.startsWith('KYC_'));
   const unsigned = Array.from(latestByType.values())
+    .filter((doc) => !doc.type.startsWith('KYC_'))
     .filter((doc) => doc.status !== 'signed')
     .map((doc) => doc.type);
 


### PR DESCRIPTION
## Summary
- ignore KYC-prefixed document types when computing missing documents for HQ requests
- exclude KYC documents from the unsigned documents list so they no longer trigger pending messaging

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e6831a2838832fad93bd6a3df151ff