### PR TITLE
Remove anexo requirement from pending documents

### DIFF
--- a/src/app/api/hq/requests/route.ts
+++ b/src/app/api/hq/requests/route.ts
@@ -11,7 +11,6 @@ const REQUIRED_DOC_TYPES = [
   "KYC_CAMARA",
   "KYC_CERT_BANCARIA",
   "CONTRATO_MARCO",
-  "ANEXO_OPERACION",
 ];
 
 type FundingRequestRow = {


### PR DESCRIPTION
## Summary
- remove the ANEXO_OPERACION document type from the required list used by the HQ requests API
- ensure requests no longer appear with that document pending once the rest of the required paperwork is present

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e688739a4c832faf39d965b12aae4a